### PR TITLE
Initial MQTTService

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ subprojects {
     maven { url "https://repo.eclipse.org/content/repositories/paho-releases/" }
     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     maven { url "https://repo.maven.apache.org/maven2" }
-    maven { url "https://d10d248laylpoq.cloudfront.net" }
   }
 
   apply from: new File(rootDir, 'gradle/java.gradle')

--- a/greengrass-mqtt-broker/build.gradle
+++ b/greengrass-mqtt-broker/build.gradle
@@ -2,9 +2,24 @@
 description = 'Greengrass - MQTT - broker'
 apply plugin: 'java'
 
+repositories {
+  maven { url "https://d10d248laylpoq.cloudfront.net" }
+}
+
 dependencies {
-  compileOnly 'com.aws.iot:evergreen-kernel:1.0-SNAPSHOT'
   compile project(':moquette-broker')
+
+  testImplementation('org.junit.jupiter:junit-jupiter-api:5.6.2')
+  testRuntime('org.junit.jupiter:junit-jupiter-engine:5.6.2')
+
+  compileOnly group: 'com.aws.iot', name: 'evergreen-kernel', version:'1.0-SNAPSHOT'
+  testCompile group: 'com.aws.iot', name: 'evergreen-kernel', version:'1.0-SNAPSHOT'
+  testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.2.4'
+  testCompile group: 'com.aws.iot', name: 'evergreen-kernel', version:'1.0-SNAPSHOT', classifier: 'tests'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 task fatJar (type : Jar) {

--- a/greengrass-mqtt-broker/src/main/java/com/aws/iot/evergreen/mqtt/broker/MQTTService.java
+++ b/greengrass-mqtt-broker/src/main/java/com/aws/iot/evergreen/mqtt/broker/MQTTService.java
@@ -1,0 +1,57 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 */
+
+package com.aws.iot.evergreen.mqtt.broker;
+
+import com.aws.iot.evergreen.config.Topics;
+import com.aws.iot.evergreen.dependency.ImplementsService;
+import com.aws.iot.evergreen.dependency.State;
+import com.aws.iot.evergreen.kernel.EvergreenService;
+
+import io.moquette.BrokerConstants;
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Properties;
+
+@ImplementsService(name = MQTTService.SERVICE_NAME, autostart = true)
+public class MQTTService extends EvergreenService {
+    public static final String SERVICE_NAME = "aws.greengrass.mqtt";
+    private final Server mqttBroker = new Server();
+
+    /**
+     * Constructor for EvergreenService.
+     *
+     * @param topics Root Configuration topic for this service
+     */
+    @Inject
+    public MQTTService(Topics topics) {
+        super(topics);
+    }
+
+    @Override
+    public void startup() {
+        try {
+            mqttBroker.startServer(getDefaultConfig());
+        } catch (IOException e) {
+            serviceErrored(e);
+            return;
+        }
+        reportState(State.RUNNING);
+    }
+
+    @Override
+    public void shutdown() {
+        mqttBroker.stopServer();
+    }
+
+    public IConfig getDefaultConfig() {
+        // TODO: Enable SSL, get certs from DCM
+        IConfig defaultConfig = new MemoryConfig(new Properties());
+        defaultConfig.setProperty(BrokerConstants.PORT_PROPERTY_NAME, "8883");
+        return defaultConfig;
+    }
+}

--- a/greengrass-mqtt-broker/src/test/java/com/aws/iot/evergreen/mqtt/broker/MQTTServiceTest.java
+++ b/greengrass-mqtt-broker/src/test/java/com/aws/iot/evergreen/mqtt/broker/MQTTServiceTest.java
@@ -1,0 +1,64 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 */
+
+package com.aws.iot.evergreen.mqtt.broker;
+
+import com.aws.iot.evergreen.dependency.State;
+import com.aws.iot.evergreen.kernel.EvergreenService;
+import com.aws.iot.evergreen.kernel.Kernel;
+import com.aws.iot.evergreen.testcommons.testutilities.EGExtension;
+import com.aws.iot.evergreen.testcommons.testutilities.EGServiceTestUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith({MockitoExtension.class, EGExtension.class})
+public class MQTTServiceTest extends EGServiceTestUtil {
+    private static final long TEST_TIME_OUT_SEC = 30L;
+
+    @TempDir
+    Path rootDir;
+
+    private Kernel kernel;
+
+    @BeforeEach
+    void setup() {
+        kernel = new Kernel();
+    }
+
+    @AfterEach
+    void cleanup() {
+        kernel.shutdown();
+    }
+
+    @Test
+    void GIVEN_Evergreen_with_broker_WHEN_start_kernel_THEN_broker_starts_on_port_8883()
+        throws InterruptedException, IOException {
+        CountDownLatch serviceRunning = new CountDownLatch(1);
+        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
+            getClass().getResource("config.yaml").toString());
+        kernel.getContext().addGlobalStateChangeListener((EvergreenService service, State was, State newState) -> {
+            if (service.getName().equals(MQTTService.SERVICE_NAME) && service.getState()
+                .equals(State.RUNNING)) {
+                serviceRunning.countDown();
+            }
+        });
+        kernel.launch();
+        assertTrue(serviceRunning.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
+
+        // Connect to port 8883 just to confirm server is listening on port
+        Socket socket = new Socket("localhost", 8883);
+        socket.close();
+    }
+}

--- a/greengrass-mqtt-broker/src/test/resources/com/aws/iot/evergreen/mqtt/broker/config.yaml
+++ b/greengrass-mqtt-broker/src/test/resources/com/aws/iot/evergreen/mqtt/broker/config.yaml
@@ -1,0 +1,10 @@
+---
+services:
+    aws.greengrass.mqtt:
+        parameters:
+    main:
+        lifecycle:
+            install:
+                all: echo All installed
+        dependencies:
+            - aws.greengrass.mqtt


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Super basic MQTT service. Starts MQTT broker on port 8883 and integrates with kernel lifecycle hooks. No auth.

**Why is this change necessary:**

**How was this change tested:**
Unit tests. Manually tested as kernel plugin.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
