### PR TITLE
Disable unauthenticated MQTT

### DIFF
--- a/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqtt/MQTTService.java
+++ b/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqtt/MQTTService.java
@@ -169,6 +169,9 @@ public class MQTTService extends PluginService {
         defaultConfig.setProperty(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, "true");
         defaultConfig.setProperty(BrokerConstants.NEED_CLIENT_AUTH, "true");
 
+        //Disable plain TCP port
+        defaultConfig.setProperty(BrokerConstants.PORT_PROPERTY_NAME, BrokerConstants.DISABLED_PORT_BIND);
+
         return defaultConfig;
     }
 }

--- a/greengrass-mqtt-broker/src/test/java/com/aws/greengrass/mqttclient/MQTTServiceTest.java
+++ b/greengrass-mqtt-broker/src/test/java/com/aws/greengrass/mqttclient/MQTTServiceTest.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.mqtt.MQTTService;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
+import io.moquette.BrokerConstants;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,11 +22,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.Socket;
 import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
@@ -68,5 +71,24 @@ public class MQTTServiceTest extends GGServiceTestUtil {
         // Connect to port 8883 just to confirm server is listening on port
         Socket socket = new Socket("localhost", 8883);
         socket.close();
+    }
+
+    @Test
+    void GIVEN_Greengrass_with_broker_WHEN_start_nucleus_THEN_broker_doesnt_start_on_plain_tcp_port()
+        throws InterruptedException {
+        CountDownLatch serviceRunning = new CountDownLatch(1);
+        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
+            getClass().getResource("config.yaml").toString());
+        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(MQTTService.SERVICE_NAME) && service.getState().equals(State.RUNNING)) {
+                serviceRunning.countDown();
+            }
+        });
+        kernel.launch();
+        assertTrue(serviceRunning.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
+
+        assertThrows(ConnectException.class, () -> {
+            new Socket("localhost", BrokerConstants.PORT);
+        });
     }
 }

--- a/greengrass-mqtt-broker/src/test/resources/com/aws/greengrass/mqttclient/config.yaml
+++ b/greengrass-mqtt-broker/src/test/resources/com/aws/greengrass/mqttclient/config.yaml
@@ -1,7 +1,6 @@
 ---
 services:
     aws.greengrass.Mqtt:
-        parameters: {}
         dependencies:
             - aws.greengrass.CertificateManager
     main:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Disable plain TCP MQTT

**Why is this change necessary:**
By default, moquette always starts up plain TCP server on 1883 alongside the TLS server on 8883 

**How was this change tested:**
Added unit test

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
