### PR TITLE
Bumping up the gradle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,7 @@ subprojects {
   }
 }
 
-task wrapper(type: Wrapper) {
-  gradleVersion = '4.6'
+wrapper {
+  gradleVersion = '6.8.2'
+  distributionUrl = distributionUrl.replace("bin", "all")
 }

--- a/gradle/lint.gradle
+++ b/gradle/lint.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'checkstyle'
-apply plugin: 'com.github.spotbugs'
 apply plugin: 'net.ltgt.errorprone'
 
 dependencies {
@@ -11,10 +10,4 @@ checkstyle {
     configFile = new File(rootDir, 'checkstyle.xml')
     ignoreFailures false
     toolVersion = '6.7'
-}
-
-spotbugs {
-    toolVersion = '3.1.1'
-    ignoreFailures true
-    omitVisitors = ['RuntimeExceptionCapture']
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
**Issue #, if available:**
Addressing the pipeline failure
**Description of changes:**
Bumping up the gradle version to 6.8.2
**Why is this change necessary:**
Pipeline is failing due to incompatible gradle and java version
**How was this change tested:**
Manually
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
