### PR TITLE
fix: use java X509Certificate instead of deprecated javax version

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -28,9 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.security.cert.X509Certificate;
 import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -165,7 +164,7 @@ final class MQTTConnection {
         SslHandler sslhandler = (SslHandler) channel.pipeline().get("ssl");
         if (sslhandler != null) {
             try {
-                X509Certificate[] certificateChain = sslhandler.engine().getSession().getPeerCertificateChain();
+                Certificate[] certificateChain = sslhandler.engine().getSession().getPeerCertificates();
                 clientData.setCertificateChain(certificateChain);
             } catch (SSLPeerUnverifiedException e) {
                 LOG.debug("Client didn't supply any certificate");
@@ -246,12 +245,12 @@ final class MQTTConnection {
     private boolean login(final ClientData clientData) {
         // handle user authentication
 
-        if (clientData.getCertificateChain().isPresent()) {
+        if (clientData.getCertificates().isPresent()) {
             if (authenticator.checkValid(clientData)) {
                 return true;
             } else {
                 LOG.error("Authenticator has rejected the MQTT credentials CId={}, certificate chain={}",
-                    clientData.getClientId(), clientData.getCertificateChain().get());
+                    clientData.getClientId(), clientData.getCertificates().get());
             }
         }
 

--- a/broker/src/main/java/io/moquette/broker/security/ClientData.java
+++ b/broker/src/main/java/io/moquette/broker/security/ClientData.java
@@ -16,14 +16,14 @@
 
 package io.moquette.broker.security;
 
-import javax.security.cert.X509Certificate;
+import java.security.cert.Certificate;
 import java.util.Optional;
 
 public class ClientData {
 
     private final String clientId;
     private Optional<String> username = Optional.empty();
-    private Optional<X509Certificate[]> certificateChain = Optional.empty();
+    private Optional<Certificate[]> certificateChain = Optional.empty();
     private Optional<byte[]> password = Optional.empty();
 
     public ClientData(String clientId) {
@@ -37,7 +37,7 @@ public class ClientData {
         this.username = Optional.ofNullable(username);
     }
 
-    public void setCertificateChain(X509Certificate[] certificateChain) {
+    public void setCertificateChain(Certificate[] certificateChain) {
         this.certificateChain = Optional.ofNullable(certificateChain);
     }
 
@@ -57,7 +57,7 @@ public class ClientData {
         return password;
     }
 
-    public Optional<X509Certificate[]> getCertificateChain() {
+    public Optional<Certificate[]> getCertificates() {
         return certificateChain;
     }
 }

--- a/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/CertificateAuthenticator.java
+++ b/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/CertificateAuthenticator.java
@@ -10,18 +10,18 @@ import io.moquette.broker.security.IAuthenticator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.security.cert.X509Certificate;
+import java.security.cert.X509Certificate;
 
 public class CertificateAuthenticator implements IAuthenticator {
     private static final Logger LOG = LoggerFactory.getLogger(CertificateAuthenticator.class);
 
     @Override
     public boolean checkValid(ClientData clientData) {
-        if (!clientData.getCertificateChain().isPresent()) {
+        if (!clientData.getCertificates().isPresent()) {
             LOG.error("No certificate in client data");
             return false;
         }
-        X509Certificate[] certificateChain = clientData.getCertificateChain().get();
+        X509Certificate[] certificateChain = (X509Certificate[]) clientData.getCertificates().get();
 
         String clientId = clientData.getClientId();
         LOG.info("Client with id {} provided X.509 certificate chain: {}", clientId, certificateChain);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Updates Moquette ClientData structure to use a `java.security.cert.Certificate` instead of the deprecated javax X509Certificate.

**Why is this change necessary:**
The two X509Certificate classes are not binary compatible.

**How was this change tested:**
Unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
