### PR TITLE
fix: remove client device config updates

### DIFF
--- a/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
+++ b/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
@@ -7,18 +7,12 @@ package com.aws.greengrass.mqttbroker;
 
 import com.aws.greengrass.certificatemanager.CertificateManager;
 import com.aws.greengrass.certificatemanager.certificate.CsrProcessingException;
-import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
-import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.ImplementsService;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.device.DeviceAuthClient;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.PluginService;
-import com.aws.greengrass.util.Coerce;
-import com.aws.greengrass.util.SerializerFactory;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.moquette.BrokerConstants;
 import io.moquette.broker.ISslContextCreator;
 import io.moquette.broker.Server;
@@ -28,27 +22,16 @@ import org.bouncycastle.operator.OperatorCreationException;
 
 import java.io.IOException;
 import java.security.KeyStoreException;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import javax.inject.Inject;
 
 @ImplementsService(name = MQTTService.SERVICE_NAME, autostart = true)
 public class MQTTService extends PluginService {
     public static final String SERVICE_NAME = "aws.greengrass.clientdevices.mqtt.Moquette";
-    public static final String CLIENT_DEVICES_AUTH_SERVICE_NAME = "aws.greengrass.clientdevices.Auth";
 
-    // Config Keys
-    private static final String RUNTIME_CONFIG_KEY = "runtime";
-    private static final String CERTIFICATES_KEY = "certificates";
-    private static final String AUTHORITIES_TOPIC = "authorities";
-    private static final String DEVICES_TOPIC = "devices";
-
-    private static MQTTBrokerKeyStore mqttBrokerKeyStore;
+    private static BrokerKeyStore brokerKeyStore;
     private final Server mqttBroker = new Server();
     private final Kernel kernel;
     private final CertificateManager certificateManager;
@@ -79,9 +62,8 @@ public class MQTTService extends PluginService {
     @Override
     protected void install() {
         try {
-            mqttBrokerKeyStore = new MQTTBrokerKeyStore(kernel.getNucleusPaths()
-                .workPath(SERVICE_NAME));
-            mqttBrokerKeyStore.initialize();
+            brokerKeyStore = new BrokerKeyStore(kernel.getNucleusPaths().workPath(SERVICE_NAME));
+            brokerKeyStore.initialize();
         } catch (IOException | KeyStoreException e) {
             serviceErrored(e);
         }
@@ -89,7 +71,7 @@ public class MQTTService extends PluginService {
 
     private synchronized void updateServerCertificate(X509Certificate cert) {
         try {
-            mqttBrokerKeyStore.updateServerCertificate(cert);
+            brokerKeyStore.updateServerCertificate(cert);
         } catch (KeyStoreException e) {
             logger.atError()
                 .cause(e)
@@ -98,50 +80,11 @@ public class MQTTService extends PluginService {
         restartMqttServer();
     }
 
-    @SuppressWarnings("PMD.UnusedFormalParameter")
-    private synchronized void updateCertificates(WhatHappened what, Topic topic) {
-        if (WhatHappened.timestampUpdated.equals(what) || WhatHappened.interiorAdded.equals(what)) {
-            return;
-        }
-        Topics clientDevicesAuthTopics = kernel.findServiceTopic(CLIENT_DEVICES_AUTH_SERVICE_NAME);
-
-        String serializedDeviceCerts =
-            Coerce.toString(clientDevicesAuthTopics.lookup(RUNTIME_CONFIG_KEY, CERTIFICATES_KEY, DEVICES_TOPIC));
-        if (serializedDeviceCerts == null) {
-            return;
-        }
-        TypeReference<HashMap<String, String>> typeRef = new TypeReference<HashMap<String, String>>() {
-        };
-        Map<String, String> deviceCerts;
-        try {
-            deviceCerts = SerializerFactory.getFailSafeJsonObjectMapper()
-                .readValue(serializedDeviceCerts, typeRef);
-        } catch (JsonProcessingException e) {
-            logger.atError()
-                .cause(e)
-                .log("failed to parse device certificates");
-            deviceCerts = Collections.emptyMap();
-        }
-
-        try {
-            List<String> caCerts =
-                (List<String>) clientDevicesAuthTopics.lookup(RUNTIME_CONFIG_KEY, CERTIFICATES_KEY,
-                    AUTHORITIES_TOPIC)
-                    .toPOJO();
-            mqttBrokerKeyStore.updateCertificates(deviceCerts, caCerts);
-        } catch (KeyStoreException | IOException | CertificateException e) {
-            logger.atError()
-                .cause(e)
-                .log("failed to update device and CA certificates");
-        }
-        restartMqttServer();
-    }
-
     @Override
     public synchronized void startup() {
         // Subscribe to client devices auth certificate updates
         try {
-            String brokerCsr = mqttBrokerKeyStore.getCsr();
+            String brokerCsr = brokerKeyStore.getCsr();
             certificateManager.subscribeToServerCertificateUpdates(brokerCsr, this::updateServerCertificate);
         } catch (KeyStoreException | CsrProcessingException | OperatorCreationException | IOException e) {
             logger.atError()
@@ -149,13 +92,6 @@ public class MQTTService extends PluginService {
             serviceErrored(e);
             return;
         }
-
-        // Subscribe to CA and device certificate updates
-        Topics clientDevicesAuthTopics = kernel.findServiceTopic(CLIENT_DEVICES_AUTH_SERVICE_NAME);
-        clientDevicesAuthTopics.lookup(RUNTIME_CONFIG_KEY, CERTIFICATES_KEY, AUTHORITIES_TOPIC)
-            .subscribe(this::updateCertificates);
-        clientDevicesAuthTopics.lookup(RUNTIME_CONFIG_KEY, CERTIFICATES_KEY, DEVICES_TOPIC)
-            .subscribe(this::updateCertificates);
 
         IConfig config = getDefaultConfig();
         ISslContextCreator sslContextCreator =
@@ -189,9 +125,9 @@ public class MQTTService extends PluginService {
         // TODO - Make configurable
         IConfig defaultConfig = new MemoryConfig(new Properties());
 
-        String password = mqttBrokerKeyStore.getJksPassword();
+        String password = brokerKeyStore.getJksPassword();
         defaultConfig.setProperty(BrokerConstants.SSL_PORT_PROPERTY_NAME, "8883");
-        defaultConfig.setProperty(BrokerConstants.JKS_PATH_PROPERTY_NAME, mqttBrokerKeyStore.getJksPath());
+        defaultConfig.setProperty(BrokerConstants.JKS_PATH_PROPERTY_NAME, brokerKeyStore.getJksPath());
         defaultConfig.setProperty(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, password);
         defaultConfig.setProperty(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, password);
         defaultConfig.setProperty(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, "true");

--- a/greengrass-mqtt-broker/src/test/java/com/aws/greengrass/mqttbroker/BrokerKeyStoreTest.java
+++ b/greengrass-mqtt-broker/src/test/java/com/aws/greengrass/mqttbroker/BrokerKeyStoreTest.java
@@ -16,22 +16,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.nio.file.Path;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class MQTTBrokerKeyStoreTest {
+public class BrokerKeyStoreTest {
     @TempDir
     Path rootDir;
 
-    private MQTTBrokerKeyStore mqttBrokerKeyStore;
+    private BrokerKeyStore brokerKeyStore;
 
     @BeforeEach
     public void setup() {
-        mqttBrokerKeyStore = new MQTTBrokerKeyStore(rootDir);
+        brokerKeyStore = new BrokerKeyStore(rootDir);
     }
 
     @Test
-    void GIVEN_MQTTBrokerKeyStore_WHEN_getKeyStore_called_THEN_basic_keystore_generated() {
-        Assertions.assertNotEquals("", mqttBrokerKeyStore.getJksPassword(),
+    void GIVEN_BrokerKeyStore_WHEN_getKeyStore_THEN_encryptedJksCreated() {
+        Assertions.assertNotEquals("", brokerKeyStore.getJksPassword(),
             "keystore password should not be empty");
-        Assertions.assertEquals(rootDir.resolve("keystore.jks").toString(), mqttBrokerKeyStore.getJksPath(),
+        Assertions.assertEquals(rootDir.resolve("keystore.jks").toString(), brokerKeyStore.getJksPath(),
             "keystore should be created in the root dir");
     }
 

--- a/greengrass-mqtt-broker/src/test/java/com/aws/greengrass/mqttbroker/ClientDeviceTrustManagerTest.java
+++ b/greengrass-mqtt-broker/src/test/java/com/aws/greengrass/mqttbroker/ClientDeviceTrustManagerTest.java
@@ -21,7 +21,7 @@ import java.security.cert.X509Certificate;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -46,7 +46,7 @@ public class ClientDeviceTrustManagerTest extends GGServiceTestUtil {
     @Test
     void GIVEN_encodableCertificate_WHEN_checkClientTrust_THEN_noExceptionThrown() throws CertificateException {
         when(mockCertificate.getEncoded()).thenReturn(new byte[]{0});
-        when(mockDeviceAuthClient.createSession(any())).thenReturn("session_id");
+        when(mockDeviceAuthClient.createSession(anyString())).thenReturn("session_id");
         ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockDeviceAuthClient);
         trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate}, "RSA");
     }
@@ -54,7 +54,7 @@ public class ClientDeviceTrustManagerTest extends GGServiceTestUtil {
     @Test
     void GIVEN_unauthenticatedCertificate_WHEN_checkClientTrust_THEN_CertificateExceptionThrown() throws CertificateEncodingException {
         when(mockCertificate.getEncoded()).thenReturn(new byte[]{0});
-        when(mockDeviceAuthClient.createSession(any())).thenReturn(null);
+        when(mockDeviceAuthClient.createSession(anyString())).thenReturn(null);
         ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockDeviceAuthClient);
         Assertions.assertThrows(CertificateException.class,
             () -> trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate}, "RSA"));
@@ -63,37 +63,37 @@ public class ClientDeviceTrustManagerTest extends GGServiceTestUtil {
     @Test
     void GIVEN_singleConnection_WHEN_getSessionForCertificate_THEN_sessionCreatedAndReturned() throws CertificateException {
         when(mockCertificate.getEncoded()).thenReturn(new byte[]{0});
-        when(mockDeviceAuthClient.createSession(any())).thenReturn("SESSION-ID");
+        when(mockDeviceAuthClient.createSession(anyString())).thenReturn("SESSION-ID");
         ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockDeviceAuthClient);
 
         // Session should be created when checking if certificate is trusted
         trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate}, "RSA");
-        verify(mockDeviceAuthClient, times(1)).createSession(any());
+        verify(mockDeviceAuthClient, times(1)).createSession(anyString());
 
         // Session should be retrievable without creating additional session
         reset(mockDeviceAuthClient);
         assertThat(trustManager.getSessionForCertificate(new X509Certificate[]{mockCertificate}), is("SESSION-ID"));
-        verify(mockDeviceAuthClient, times(0)).createSession(any());
+        verify(mockDeviceAuthClient, times(0)).createSession(anyString());
     }
 
     @Test
     void GIVEN_twoConnectionsWithSameCert_WHEN_getSessionForCertificate_THEN_sessionIsCreatedOnDemand() throws CertificateException {
         when(mockCertificate.getEncoded()).thenReturn(new byte[]{0});
-        when(mockDeviceAuthClient.createSession(any())).thenReturn("SESSION-ID");
+        when(mockDeviceAuthClient.createSession(anyString())).thenReturn("SESSION-ID");
 
         // Two calls to checkClientTrusted should only result in 1 session being created
         ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockDeviceAuthClient);
         trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate}, "RSA");
         trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate}, "RSA");
-        verify(mockDeviceAuthClient, times(1)).createSession(any());
+        verify(mockDeviceAuthClient, times(1)).createSession(anyString());
 
         // Reset mock to return new session ID
-        when(mockDeviceAuthClient.createSession(any())).thenReturn("SESSION-ID2");
+        when(mockDeviceAuthClient.createSession(anyString())).thenReturn("SESSION-ID2");
 
         // A second session should be created after the first is retrieved
         assertThat(trustManager.getSessionForCertificate(new X509Certificate[]{mockCertificate}), is("SESSION-ID"));
         assertThat(trustManager.getSessionForCertificate(new X509Certificate[]{mockCertificate}), is("SESSION-ID2"));
-        verify(mockDeviceAuthClient, times(2)).createSession(any());
+        verify(mockDeviceAuthClient, times(2)).createSession(anyString());
     }
 
     @Test
@@ -104,11 +104,11 @@ public class ClientDeviceTrustManagerTest extends GGServiceTestUtil {
 
         // Two connections with different certificates should result in two sessions
         ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockDeviceAuthClient);
-        when(mockDeviceAuthClient.createSession(any())).thenReturn("SESSION-ID");
+        when(mockDeviceAuthClient.createSession(anyString())).thenReturn("SESSION-ID");
         trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate}, "RSA");
-        when(mockDeviceAuthClient.createSession(any())).thenReturn("SESSION-ID2");
+        when(mockDeviceAuthClient.createSession(anyString())).thenReturn("SESSION-ID2");
         trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate2}, "RSA");
-        verify(mockDeviceAuthClient, times(2)).createSession(any());
+        verify(mockDeviceAuthClient, times(2)).createSession(anyString());
 
         assertThat(trustManager.getSessionForCertificate(new X509Certificate[]{mockCertificate}), is("SESSION-ID"));
         assertThat(trustManager.getSessionForCertificate(new X509Certificate[]{mockCertificate2}), is("SESSION-ID2"));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change removes CA certificates and client devices certificates from the MQTT broker keystore, since this is no longer used to authenticate connecting clients. Instead, the client device auth component is responsible for this.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
