### PR TITLE
fix: disallow anonymous sessions

### DIFF
--- a/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
+++ b/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
@@ -130,7 +130,7 @@ public class MQTTService extends PluginService {
         defaultConfig.setProperty(BrokerConstants.JKS_PATH_PROPERTY_NAME, brokerKeyStore.getJksPath());
         defaultConfig.setProperty(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, password);
         defaultConfig.setProperty(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, password);
-        defaultConfig.setProperty(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, "true");
+        defaultConfig.setProperty(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, "false");
         defaultConfig.setProperty(BrokerConstants.NEED_CLIENT_AUTH, "true");
 
         //Disable plain TCP port


### PR DESCRIPTION
Moquette CONNECT handling has a bug where authentication failures will
still succeed if anonymous sessions are allowed. This is a bug in the
Moquette login code, but since Greengrass requires client certificates,
we can disable anonymous sessions as a workaround. The actual fix should
be in Moquette itself.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
