### PR TITLE
fix: register disconnect handler on server restart

### DIFF
--- a/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
+++ b/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
@@ -18,12 +18,14 @@ import io.moquette.broker.ISslContextCreator;
 import io.moquette.broker.Server;
 import io.moquette.broker.config.IConfig;
 import io.moquette.broker.config.MemoryConfig;
+import io.moquette.interception.InterceptHandler;
 import org.bouncycastle.operator.OperatorCreationException;
 
 import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import javax.inject.Inject;
 
@@ -37,6 +39,7 @@ public class MQTTService extends PluginService {
     private final CertificateManager certificateManager;
     private final ClientDeviceTrustManager clientDeviceTrustManager;
     private final ClientDeviceAuthorizer clientDeviceAuthorizer;
+    private final List<InterceptHandler> interceptHandlers;
 
     private boolean serverRunning = false;
 
@@ -57,6 +60,7 @@ public class MQTTService extends PluginService {
         this.certificateManager = certificateManager;
         this.clientDeviceTrustManager = new ClientDeviceTrustManager(deviceAuthClient);
         this.clientDeviceAuthorizer = new ClientDeviceAuthorizer(clientDeviceTrustManager, deviceAuthClient);
+        this.interceptHandlers = Collections.singletonList(clientDeviceAuthorizer.new ConnectionTerminationListener());
     }
 
     @Override
@@ -96,8 +100,7 @@ public class MQTTService extends PluginService {
         IConfig config = getDefaultConfig();
         ISslContextCreator sslContextCreator =
             new GreengrassMoquetteSslContextCreator(config, clientDeviceTrustManager);
-        mqttBroker.startServer(config,
-            Collections.singletonList(clientDeviceAuthorizer.new ConnectionTerminationListener()), sslContextCreator,
+        mqttBroker.startServer(config, interceptHandlers, sslContextCreator,
             clientDeviceAuthorizer, clientDeviceAuthorizer);
         serverRunning = true;
         reportState(State.RUNNING);
@@ -117,8 +120,7 @@ public class MQTTService extends PluginService {
             IConfig config = getDefaultConfig();
             ISslContextCreator sslContextCreator =
                 new GreengrassMoquetteSslContextCreator(config, clientDeviceTrustManager);
-            mqttBroker.startServer(config,
-                Collections.singletonList(clientDeviceAuthorizer.new ConnectionTerminationListener()),
+            mqttBroker.startServer(config, interceptHandlers,
                 sslContextCreator, clientDeviceAuthorizer, clientDeviceAuthorizer);
         }
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
register disconnect handler on server restart

**Why is this change necessary:**
otherwise auth session is not closed on disconnecting after server is restarted

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
