### PR TITLE
feat(greengrass broker): only allow connection over TLS 1.2

### DIFF
--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -68,6 +68,7 @@ public final class BrokerConstants {
     public static final String NETTY_EPOLL_PROPERTY_NAME = "netty.epoll";
     public static final String NETTY_MAX_BYTES_PROPERTY_NAME = "netty.mqtt.message_size";
     public static final int DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE = 8092;
+    public static final String NETTY_ENABLED_TLS_PROTOCOLS_PROPERTY_NAME = "netty.enabled.tls.protocols";
     public static final String IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME = "immediate_buffer_flush";
     public static final String METRICS_ENABLE_PROPERTY_NAME = "use_metrics";
     public static final String METRICS_LIBRATO_EMAIL_PROPERTY_NAME = "metrics.librato.email";

--- a/broker/src/main/java/io/moquette/broker/DefaultMoquetteSslContextCreator.java
+++ b/broker/src/main/java/io/moquette/broker/DefaultMoquetteSslContextCreator.java
@@ -89,6 +89,14 @@ class DefaultMoquetteSslContextCreator implements ISslContextCreator {
             if (Boolean.valueOf(sNeedsClientAuth)) {
                 addClientAuthentication(ks, contextBuilder);
             }
+
+            // if enabled tls protocols are not provided, we use the default
+            String enabledTLSProtocols = props.getProperty(BrokerConstants.NETTY_ENABLED_TLS_PROTOCOLS_PROPERTY_NAME);
+            if (enabledTLSProtocols != null) {
+                LOG.info(String.format("Enabled TLS Protocols: {%s}", enabledTLSProtocols));
+                contextBuilder.protocols(enabledTLSProtocols.split(";"));
+            }
+            
             contextBuilder.sslProvider(sslProvider);
             SslContext sslContext = contextBuilder.build();
             LOG.info("The SSL context has been initialized successfully.");

--- a/greengrass-mqtt-broker/pom.xml
+++ b/greengrass-mqtt-broker/pom.xml
@@ -51,13 +51,13 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.1.0-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.1.0-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/GreengrassMoquetteSslContextCreator.java
+++ b/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/GreengrassMoquetteSslContextCreator.java
@@ -82,6 +82,14 @@ public class GreengrassMoquetteSslContextCreator implements ISslContextCreator {
             if (Boolean.parseBoolean(needsClientAuth)) {
                 addClientAuthentication(ks, contextBuilder);
             }
+
+            // if enabled tls protocols are not provided, we use the default
+            String enabledTLSProtocols = props.getProperty(BrokerConstants.NETTY_ENABLED_TLS_PROTOCOLS_PROPERTY_NAME);
+            if (enabledTLSProtocols != null) {
+                LOG.info(String.format("Enabled TLS Protocols: {%s}", enabledTLSProtocols));
+                contextBuilder.protocols(enabledTLSProtocols.split(";"));
+            }
+
             contextBuilder.sslProvider(sslProvider);
             SslContext sslContext = contextBuilder.build();
             LOG.info("The SSL context has been initialized successfully.");

--- a/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
+++ b/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
@@ -137,6 +137,7 @@ public class MQTTService extends PluginService {
         defaultConfig.setProperty(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, "false");
         defaultConfig.setProperty(BrokerConstants.NEED_CLIENT_AUTH, "true");
         defaultConfig.setProperty(BrokerConstants.IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME, "true");
+        defaultConfig.setProperty(BrokerConstants.NETTY_ENABLED_TLS_PROTOCOLS_PROPERTY_NAME, "TLSv1.2");
 
         //Disable plain TCP port
         defaultConfig.setProperty(BrokerConstants.PORT_PROPERTY_NAME, BrokerConstants.DISABLED_PORT_BIND);


### PR DESCRIPTION
**Issue #, if available:**
GG-35399
**Description of changes:**
GG broker should only allow connections over TLS 1.2
We set the netty ssl context to use only TLS v1.2
**Why is this change necessary:**
To disallow connections over 1.1 and 1.0 TLS versions.
**How was this change tested:**
This has been tested using a UAT.
The error stack from the greengrass logs:
`io.moquette.broker.NewNettyMQTTHandler:
Unexpected exception while processing MQTT message.
Closing Netty channel. CId=null. {}
javax.net.ssl.SSLHandshakeException
TLSv1 is not enabled or supported in server context`

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
