### PR TITLE
refactor: subscribe uses topicfilter resource type

### DIFF
--- a/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizer.java
+++ b/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizer.java
@@ -111,7 +111,7 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
             .kv("user", user)
             .kv(CLIENT_ID, client)
             .log("MQTT subscribe request");
-        return canDevicePerform(client, "mqtt:subscribe", "mqtt:topic:" + topic);
+        return canDevicePerform(client, "mqtt:subscribe", "mqtt:topicfilter:" + topic);
     }
 
     private boolean canDevicePerform(String client, String operation, String resource) {

--- a/greengrass-mqtt-broker/src/test/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizerTest.java
+++ b/greengrass-mqtt-broker/src/test/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizerTest.java
@@ -71,7 +71,7 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
     }
 
     void configureSubscribeResponse(String session, String topic, boolean doAllow) throws AuthorizationException {
-        configureAuthResponse(session, "mqtt:subscribe", "mqtt:topic:" + topic, doAllow);
+        configureAuthResponse(session, "mqtt:subscribe", "mqtt:topicfilter:" + topic, doAllow);
     }
 
     void configureSubscribeResponse(boolean doAllow) throws AuthorizationException {


### PR DESCRIPTION
This change updates the mqtt:subscribe action to use the
mqtt:topicfilter resource type instead of mqtt:topic. This better aligns
with AWS IoT certificate policies

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
