### PR TITLE
feat: add per channel read/write rate limiting to MQTT NettyAcceptor

### DIFF
--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -80,10 +80,10 @@ public final class BrokerConstants {
 
     public static final String STORAGE_CLASS_NAME = "storage_class";
 
-    public static final String TRAFFIC_CHANNEL_WRITE_LIMIT_NAME = "traffic.channel.write.limit";
-    public static final int DEFAULT_TRAFFIC_CHANNEL_WRITE_LIMIT_BYTES = 512 * 1024;
-    public static final String TRAFFIC_CHANNEL_READ_LIMIT_NAME = "traffic.channel.read.limit";
-    public static final int DEFAULT_TRAFFIC_CHANNEL_READ_LIMIT_BYTES = 512 * 1024;
+    public static final String NETTY_CHANNEL_WRITE_LIMIT_PROPERTY_NAME = "netty.channel.write.limit";
+    public static final int DEFAULT_NETTY_CHANNEL_WRITE_LIMIT_BYTES = 512 * 1024;
+    public static final String NETTY_CHANNEL_READ_LIMIT_PROPERTY_NAME = "netty.channel.read.limit";
+    public static final int DEFAULT_NETTY_CHANNEL_READ_LIMIT_BYTES = 512 * 1024;
 
     private BrokerConstants() {
     }

--- a/broker/src/main/java/io/moquette/broker/NewNettyAcceptor.java
+++ b/broker/src/main/java/io/moquette/broker/NewNettyAcceptor.java
@@ -169,10 +169,10 @@ class NewNettyAcceptor {
         nettyChannelTimeoutSeconds = props.intProp(BrokerConstants.NETTY_CHANNEL_TIMEOUT_SECONDS_PROPERTY_NAME, 10);
         maxBytesInMessage = props.intProp(BrokerConstants.NETTY_MAX_BYTES_PROPERTY_NAME,
                 BrokerConstants.DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE);
-        trafficMaxReadBytesPerSecondPerChannel = Math.max(props.intProp(BrokerConstants.TRAFFIC_CHANNEL_READ_LIMIT_NAME,
-            BrokerConstants.DEFAULT_TRAFFIC_CHANNEL_READ_LIMIT_BYTES), 0);
-        trafficMaxWriteBytesPerSecondPerChannel = Math.max(props.intProp(BrokerConstants.TRAFFIC_CHANNEL_WRITE_LIMIT_NAME,
-            BrokerConstants.DEFAULT_TRAFFIC_CHANNEL_WRITE_LIMIT_BYTES), 0);
+        trafficMaxReadBytesPerSecondPerChannel = Math.max(props.intProp(BrokerConstants.NETTY_CHANNEL_READ_LIMIT_PROPERTY_NAME,
+            BrokerConstants.DEFAULT_NETTY_CHANNEL_READ_LIMIT_BYTES), 0);
+        trafficMaxWriteBytesPerSecondPerChannel = Math.max(props.intProp(BrokerConstants.NETTY_CHANNEL_WRITE_LIMIT_PROPERTY_NAME,
+            BrokerConstants.DEFAULT_NETTY_CHANNEL_WRITE_LIMIT_BYTES), 0);
         boolean epoll = props.boolProp(BrokerConstants.NETTY_EPOLL_PROPERTY_NAME, false);
         if (epoll) {
             LOG.info("Netty is using Epoll");


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add traffic shaping to the MQTT pipeline.

Defaults to 512 KiB / second for writing/reading to a channel
0 indicates no limit
Negative numbers are treated as 0

**Why is this change necessary:**
This is necessary so that no single connection can overwhelm the broker and hog resources

**How was this change tested:**
Manually testing with 10 GGADs publishing messages at 100 tps. The broker did not process 1000 tps of messages, it throttled them based on the configured rate.

For example, at 10kb read/write and 1kb qos1 messages published by 10 devices, 10 messages per channel per second were accepted.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
