### PR TITLE
fix: add error-prone config for JDK8

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -19,7 +19,32 @@
         <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
         <paho.version>1.2.5</paho.version>
         <h2.version>1.4.199</h2.version>
+        <javac.version>9+181-r4173-1</javac.version>
     </properties>
+
+    <!-- required to use error-prone with JDK 8 - https://errorprone.info/docs/installation -->
+    <profiles>
+      <profile>
+        <id>jdk8</id>
+        <activation>
+          <jdk>1.8</jdk>
+        </activation>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                <fork>true</fork>
+                <compilerArgs combine.children="append">
+                  <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
+                </compilerArgs>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Configuration is needed to use error-prone with JDK8.

```
<span><span>
[INFO] Compiling 87 source files to /codebuild/output/src732974186/src/broker/target/classes
--


</span></span><span><span>
An exception has occurred in the compiler (1.8.0_292). Please file a bug against the Java compiler via the Java bug reporting page (http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com) for duplicates. Include your program and the following diagnostic in your report. Thank you.
--


</span></span><span><span>
java.lang.RuntimeException: java.lang.NoSuchMethodError: com.sun.tools.javac.util.JavacMessages.add(Lcom/sun/tools/javac/util/JavacMessages$ResourceBundleHelper;)V
--


</span></span><span><span>
at com.sun.tools.javac.main.Main.compile(Main.java:473)
--


</span></span><span><span>
at com.sun.tools.javac.api.JavacTaskImpl.doCall(JavacTaskImpl.java:129)
--


</span></span><span><span>
at com.sun.tools.javac.api.JavacTaskImpl.call(JavacTaskImpl.java:138)
--


</span></span><span><span>
at org.codehaus.plexus.compiler.javac.JavaxToolsCompiler.compileInProcess(JavaxToolsCompiler.java:126)
--


</span></span><span><span>
at org.codehaus.plexus.compiler.javac.JavacCompiler.performCompile(JavacCompiler.java:174)
--


</span></span><span><span>
at org.apache.maven.plugin.compiler.AbstractCompilerMojo.execute(AbstractCompilerMojo.java:1129)
--


</span></span><span><span>
at org.apache.maven.plugin.compiler.CompilerMojo.execute(CompilerMojo.java:188)
--


</span></span><span><span>
at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
--


</span></span><span><span>
at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)
--


</span></span><span><span>
at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)
--


</span></span><span><span>
at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)
--


</span></span><span><span>
at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
--


</span></span><span><span>
at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
--


</span></span><span><span>
at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
--


</span></span><span><span>
at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
--


</span></span><span><span>
at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
--


</span></span><span><span>
at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
--


</span></span><span><span>
at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
--


</span></span><span><span>
at org.apache.maven.cli.MavenCli.execute(MavenCli.java:957)
--


</span></span><span><span>
at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:289)
--


</span></span><span><span>
at org.apache.maven.cli.MavenCli.main(MavenCli.java:193)
--


</span></span><span><span>
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
--


</span></span><span><span>
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
--


</span></span><span><span>
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
--


</span></span><span><span>
at java.lang.reflect.Method.invoke(Method.java:498)
--


</span></span><span><span>
at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
--


</span></span><span><span>
at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
--


</span></span><span><span>
at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
--


</span></span><span><span>
at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
--


</span></span><span><span>
Caused by: java.lang.NoSuchMethodError: com.sun.tools.javac.util.JavacMessages.add(Lcom/sun/tools/javac/util/JavacMessages$ResourceBundleHelper;)V
--


</span></span><span><span>
at com.google.errorprone.BaseErrorProneJavaCompiler.setupMessageBundle(BaseErrorProneJavaCompiler.java:200)
--


</span></span><span><span>
at com.google.errorprone.ErrorProneJavacPlugin.init(ErrorProneJavacPlugin.java:40)
--


</span></span><span><span>
at com.sun.tools.javac.main.Main.compile(Main.java:470)
--


</span></span><span><span>    ... 28 more
</span></span>
```

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
