### PR TITLE
feat: add session queue size limit

### DIFF
--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -82,6 +82,7 @@ public final class BrokerConstants {
     public static final String BUGSNAG_TOKEN_PROPERTY_NAME = "bugsnag.token";
 
     public static final String STORAGE_CLASS_NAME = "storage_class";
+    public static final String SESSION_QUEUE_SIZE = "session_queue_size";
 
     public static final String NETTY_CHANNEL_WRITE_LIMIT_PROPERTY_NAME = "netty.channel.write.limit";
     public static final int DEFAULT_NETTY_CHANNEL_WRITE_LIMIT_BYTES = 512 * 1024;

--- a/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
+++ b/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
@@ -5,16 +5,42 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import io.moquette.BrokerConstants;
+import io.moquette.broker.config.IConfig;
 
 public class MemoryQueueRepository implements IQueueRepository {
+    int capacity;
 
+    public MemoryQueueRepository() {
+        capacity = 0;
+    }
+
+    public MemoryQueueRepository(IConfig props) {
+        int capacity = Integer.parseInt(props.getProperty(BrokerConstants.SESSION_QUEUE_SIZE, "0"));
+        if (capacity < 0) {
+            capacity = 0;
+        }
+        this.capacity = capacity;
+    }
+
+    // TODO: Clients connecting with random client IDs will leak
+    // these sessions. There should be logic to remove these
     private Map<String, Queue<SessionRegistry.EnqueuedMessage>> queues = new HashMap<>();
 
     @Override
     public Queue<SessionRegistry.EnqueuedMessage> createQueue(String cli, boolean clean) {
-        final ConcurrentLinkedQueue<SessionRegistry.EnqueuedMessage> queue = new ConcurrentLinkedQueue<>();
-        queues.put(cli, queue);
-        return queue;
+        if (capacity == 0) {
+            final ConcurrentLinkedQueue<SessionRegistry.EnqueuedMessage> queue = new ConcurrentLinkedQueue<>();
+            queues.put(cli, queue);
+            return queue;
+        } else {
+            // Cannot specify capacity on ConcurrentLinkedQueue
+            final LinkedBlockingQueue<SessionRegistry.EnqueuedMessage> queue = new LinkedBlockingQueue<>(capacity);
+            queues.put(cli, queue);
+            return queue;
+        }
     }
 
     @Override

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -170,7 +170,7 @@ public class Server {
         } else {
             LOG.trace("Configuring in-memory subscriptions store");
             subscriptionsRepository = new MemorySubscriptionsRepository();
-            queueRepository = new MemoryQueueRepository();
+            queueRepository = new MemoryQueueRepository(config);
             retainedRepository = new MemoryRetainedRepository();
         }
 

--- a/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
+++ b/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
@@ -134,6 +134,7 @@ public class MQTTService extends PluginService {
         defaultConfig.setProperty(BrokerConstants.NEED_CLIENT_AUTH, "true");
         defaultConfig.setProperty(BrokerConstants.IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME, "true");
         defaultConfig.setProperty(BrokerConstants.NETTY_ENABLED_TLS_PROTOCOLS_PROPERTY_NAME, "TLSv1.2");
+        defaultConfig.setProperty(BrokerConstants.SESSION_QUEUE_SIZE, "10000");
 
         //Disable plain TCP port
         defaultConfig.setProperty(BrokerConstants.PORT_PROPERTY_NAME, BrokerConstants.DISABLED_PORT_BIND);


### PR DESCRIPTION
This change adds a maximum size limit on session queues. If the queue
size is exceeded, the MQTT session is terminated and the queue is
dropped. This acts as a protection against misbehaving or slow clients.
Without this change, the session queue will grow without bound until
Nucleus runs out of memory.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
