### PR TITLE
fix: force restart on server cert change

### DIFF
--- a/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
+++ b/greengrass-mqtt-broker/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
@@ -93,7 +93,7 @@ public class MQTTService extends PluginService {
         } catch (KeyStoreException e) {
             logger.atError().cause(e).log("Failed to update MQTT broker certificate");
         }
-        startWithProperties(getProperties());
+        startWithProperties(getProperties(), true);
     }
 
     @Override
@@ -122,7 +122,11 @@ public class MQTTService extends PluginService {
     }
 
     private synchronized void startWithProperties(Properties properties) {
-        if (runningProperties != null && runningProperties.equals(properties)) {
+        startWithProperties(properties, false);
+    }
+
+    private synchronized void startWithProperties(Properties properties, boolean forceRestart) {
+        if (runningProperties != null && runningProperties.equals(properties) && !forceRestart) {
             // Nothing to do
             return;
         }


### PR DESCRIPTION
762cce98 introduces a regression where server certificate updates no
longer result in a server restart, due to the fact that config
properties haven't changed. A server restart is required in order for
the new certificate to be presented to client devices.

Without this change, clients will not be able to connect without
disabling host name verification checks.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
