### PR TITLE
fix: properly handle floating point ssl_port

### DIFF
--- a/integration/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
+++ b/integration/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
@@ -154,8 +154,10 @@ public class MQTTService extends PluginService {
         String password = brokerKeyStore.getJksPassword();
         p.setProperty(BrokerConstants.HOST_PROPERTY_NAME,
             Coerce.toString(moquetteTopics.lookup(BrokerConstants.HOST_PROPERTY_NAME).dflt(BrokerConstants.HOST)));
+        // Due to a deserialization bug in GSON during group deployments, this value can become a floating point
+        // instead of an int. As a workaround, coerce to an int before converting back to a string
         p.setProperty(BrokerConstants.SSL_PORT_PROPERTY_NAME,
-            Coerce.toString(moquetteTopics.lookup(BrokerConstants.SSL_PORT_PROPERTY_NAME).dflt("8883")));
+            String.valueOf(Coerce.toInt(moquetteTopics.lookup(BrokerConstants.SSL_PORT_PROPERTY_NAME).dflt("8883"))));
         p.setProperty(BrokerConstants.JKS_PATH_PROPERTY_NAME, brokerKeyStore.getJksPath());
         p.setProperty(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, password);
         p.setProperty(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, password);

--- a/integration/src/test/resources/com/aws/greengrass/mqttbroker/nonDefaultPort.yaml
+++ b/integration/src/test/resources/com/aws/greengrass/mqttbroker/nonDefaultPort.yaml
@@ -8,7 +8,9 @@ services:
     aws.greengrass.clientdevices.mqtt.Moquette:
         configuration:
             moquette:
-                ssl_port: 9000
+                # This should be an int, but a GSON bug can result in this becoming a floating point
+                # so this ensures we have test coverage for that scenario
+                ssl_port: 9000.0
     aws.greengrass.clientdevices.Auth: {}
     main:
         lifecycle:


### PR DESCRIPTION
A serialization bug in GSON can result in ssl_port configuration
becoming a floating point value instead of an int. This happens during
group deployments (but not thing deployments). This fix is a workaround
to be more robust. Without this change, Moquette may fail to start.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
