### PR TITLE
fix: refactor H2PersistentQueueTest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,21 +9,30 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
         with:
             fetch-depth: 0
-      # Temporarily disable to allow for Moquette update
       - uses: wagoid/commitlint-github-action@v2
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Build with Maven
+      - name: Build with Maven (not Windows)
         env:
             AWS_REGION: us-west-2
         run: mvn -U -ntp verify
+        if: matrix.os != 'windows-latest'
+      - name: Build with Maven (Windows)
+        env:
+            AWS_REGION: us-west-2
+        run: mvn -U -ntp verify
+        shell: cmd
+        if: matrix.os == 'windows-latest'
       - name: Upload Failed Test Report
         uses: actions/upload-artifact@v1.0.0
         if: failure()
@@ -32,13 +41,15 @@ jobs:
           path: integration/target/surefire-reports
       - name: Upload Coverage
         uses: actions/upload-artifact@v1.0.0
-        if: always()
+        if: matrix.os == 'ubuntu-latest'
         with:
-          name: Coverage Report
+          name: Coverage Report ${{ matrix.os }}
           path: integration/target/jacoco-report
       - name: Convert Jacoco unit test report to Cobertura
         run: python3 .github/scripts/cover2cover.py integration/target/jacoco-report/jacoco.xml > integration/target/jacoco-report/cobertura.xml
+        if: matrix.os == 'ubuntu-latest'
       - name: cobertura-report-unit-test
+        if: matrix.os == 'ubuntu-latest'
         uses: shaguptashaikh/cobertura-action@master
         continue-on-error: true
         with:

--- a/moquette/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
+++ b/moquette/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
@@ -40,11 +40,11 @@ public class H2PersistentQueueTest {
 
     @AfterEach
     public void tearDown() {
+        this.mvStore.close();
         File dbFile = new File(BrokerConstants.DEFAULT_PERSISTENT_PATH);
         if (dbFile.exists()) {
-            dbFile.delete();
+            assertTrue(dbFile.delete());
         }
-        assertFalse(dbFile.exists());
     }
 
     @Test


### PR DESCRIPTION
**Issue :** Deleting `moquette_store.h2` during `H2PersistentQueueTest` tear-down fails due to the open `MVStore` object holding a reference to the file `moquette_store.h2` on Windows.

**Description of changes:** `Close()`es opened `MVStore` before removing the store file: `moquette_store.h2`. Also adds GitHub workflow steps for Windows build.

**How was this change tested:** `mvn -U -ntp verify` on Windows with jdk-8

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
