### PR TITLE
fix: set default max message size to 128KiB

### DIFF
--- a/integration/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
+++ b/integration/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
@@ -164,6 +164,8 @@ public class MQTTService extends PluginService {
         p.setProperty(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, "false");
         p.setProperty(BrokerConstants.NEED_CLIENT_AUTH, "true");
         p.setProperty(BrokerConstants.IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME, "true");
+        p.setProperty(BrokerConstants.NETTY_MAX_BYTES_PROPERTY_NAME, String.valueOf(Coerce
+            .toInt(moquetteTopics.lookup(BrokerConstants.NETTY_MAX_BYTES_PROPERTY_NAME).dflt("131072")))); // 128KiB
         p.setProperty(BrokerConstants.NETTY_ENABLED_TLS_PROTOCOLS_PROPERTY_NAME, "TLSv1.2");
         p.setProperty(BrokerConstants.NETTY_CHANNEL_WRITE_LIMIT_PROPERTY_NAME, Coerce.toString(
             rootConfig.lookup(BrokerConstants.NETTY_CHANNEL_WRITE_LIMIT_PROPERTY_NAME)


### PR DESCRIPTION
Moquette uses a default message size of 8092 bytes by default. This is
well below the IoT Core limit of 128KiB. This change updates the default
message size to 128KiB and exposes the configuration option to customers
can further increase it up to the max size in the MQTT specification.

**Issue #, if available:**
Resolves #68 

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
