### PR TITLE
fix: deduplicate subscription to certificate changes

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -28,19 +28,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.0</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.5.13</version>
+            <version>4.4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.7.0</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -71,13 +71,13 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-            <version>4.0.1</version>
+            <version>4.6.0</version>
         </dependency>
         <dependency>
             <groupId>io.moquette</groupId>

--- a/integration/src/test/java/com/aws/greengrass/mqttbroker/MQTTServiceTest.java
+++ b/integration/src/test/java/com/aws/greengrass/mqttbroker/MQTTServiceTest.java
@@ -6,9 +6,11 @@
 package com.aws.greengrass.mqttbroker;
 
 import com.aws.greengrass.certificatemanager.CertificateManager;
+import com.aws.greengrass.certificatemanager.certificate.CsrProcessingException;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -16,18 +18,28 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.file.Path;
+import java.security.KeyStoreException;
+import java.security.cert.X509Certificate;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class MQTTServiceTest extends GGServiceTestUtil {
@@ -73,11 +85,24 @@ public class MQTTServiceTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_defaultConfig_WHEN_startComponent_THEN_brokerStartsOnPort8883() throws InterruptedException {
+    void GIVEN_defaultConfig_WHEN_startComponent_THEN_brokerStartsOnPort8883_and_subscriptions_dont_duplicate()
+        throws InterruptedException, ServiceLoadException, CsrProcessingException, KeyStoreException {
         startNucleusWithConfig("config.yaml");
+        ArgumentCaptor<Consumer<X509Certificate>> captor = ArgumentCaptor.forClass(Consumer.class);
+        Mockito.doNothing().when(mockCertificateManager).subscribeToServerCertificateUpdates(anyString(), captor.capture());
+        verify(mockCertificateManager, timeout(5_000).times(1)).subscribeToServerCertificateUpdates(any(), any());
+        kernel.locate(MQTTService.SERVICE_NAME).requestRestart();
+        verify(mockCertificateManager, timeout(5_000).times(2)).subscribeToServerCertificateUpdates(any(), any());
+        kernel.locate(MQTTService.SERVICE_NAME).requestRestart();
+        verify(mockCertificateManager, timeout(5_000).times(3)).subscribeToServerCertificateUpdates(any(), any());
+        kernel.locate(MQTTService.SERVICE_NAME).requestRestart();
+        verify(mockCertificateManager, timeout(5_000).times(4)).subscribeToServerCertificateUpdates(any(), any());
+        Thread.sleep(1_000);
 
         assertThat(isListeningOnPort(8883), is(true));
         assertThat(isListeningOnPort(1883), is(false));
+        // Validate that subscription requests are de-duplicateable because they are all exactly equal
+        assertThat(captor.getAllValues().stream().distinct().count(), equalTo(1L));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Ensure that subscriptions to certificate rotation are absolutely deduplicated. Using a method reference is not able to be deduplicated because it just creates an inline lambda. Storing a single reference to that method reference is acceptable though.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
