### PR TITLE
feat: peer cert as username config option

### DIFF
--- a/moquette-0.16/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/moquette-0.16/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -49,6 +49,7 @@ public final class BrokerConstants {
     public static final String KEY_STORE_PASSWORD_PROPERTY_NAME = "key_store_password";
     public static final String KEY_MANAGER_PASSWORD_PROPERTY_NAME = "key_manager_password";
     public static final String ALLOW_ANONYMOUS_PROPERTY_NAME = "allow_anonymous";
+    public static final String PEER_CERTIFICATE_AS_USERNAME = "peer_certificate_as_username";
     public static final String REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT = "reauthorize_subscriptions_on_connect";
     public static final String ALLOW_ZERO_BYTE_CLIENT_ID_PROPERTY_NAME = "allow_zero_byte_client_id";
     public static final String ACL_FILE_PROPERTY_NAME = "acl_file";

--- a/moquette-0.16/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
+++ b/moquette-0.16/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
@@ -66,7 +66,7 @@ class BrokerConfiguration {
         return immediateBufferFlush;
     }
 
-    public boolean peerCertificateAsUsername() {
+    public boolean isPeerCertificateAsUsername() {
         return peerCertificateAsUsername;
     }
 }

--- a/moquette-0.16/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
+++ b/moquette-0.16/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
@@ -31,7 +31,7 @@ class BrokerConfiguration {
         allowZeroByteClientId = props.boolProp(BrokerConstants.ALLOW_ZERO_BYTE_CLIENT_ID_PROPERTY_NAME, false);
         reauthorizeSubscriptionsOnConnect = props.boolProp(BrokerConstants.REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT, false);
         immediateBufferFlush = props.boolProp(BrokerConstants.IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME, false);
-        peerCertificateAsUsername = props.boolProp(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, false);
+        peerCertificateAsUsername = props.boolProp(BrokerConstants.PEER_CERTIFICATE_AS_USERNAME, false);
     }
 
     public BrokerConfiguration(boolean allowAnonymous, boolean allowZeroByteClientId,

--- a/moquette-0.16/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
+++ b/moquette-0.16/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
@@ -24,20 +24,30 @@ class BrokerConfiguration {
     private final boolean allowZeroByteClientId;
     private final boolean reauthorizeSubscriptionsOnConnect;
     private final boolean immediateBufferFlush;
+    private final boolean peerCertificateAsUsername;
 
     BrokerConfiguration(IConfig props) {
         allowAnonymous = props.boolProp(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, true);
         allowZeroByteClientId = props.boolProp(BrokerConstants.ALLOW_ZERO_BYTE_CLIENT_ID_PROPERTY_NAME, false);
         reauthorizeSubscriptionsOnConnect = props.boolProp(BrokerConstants.REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT, false);
         immediateBufferFlush = props.boolProp(BrokerConstants.IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME, false);
+        peerCertificateAsUsername = props.boolProp(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, false);
     }
 
     public BrokerConfiguration(boolean allowAnonymous, boolean allowZeroByteClientId,
                                boolean reauthorizeSubscriptionsOnConnect, boolean immediateBufferFlush) {
+        this(allowAnonymous, allowZeroByteClientId,
+            reauthorizeSubscriptionsOnConnect, immediateBufferFlush, false);
+    }
+
+    public BrokerConfiguration(boolean allowAnonymous, boolean allowZeroByteClientId,
+                               boolean reauthorizeSubscriptionsOnConnect, boolean immediateBufferFlush,
+                               boolean peerCertificateAsUsername) {
         this.allowAnonymous = allowAnonymous;
         this.allowZeroByteClientId = allowZeroByteClientId;
         this.reauthorizeSubscriptionsOnConnect = reauthorizeSubscriptionsOnConnect;
         this.immediateBufferFlush = immediateBufferFlush;
+        this.peerCertificateAsUsername = peerCertificateAsUsername;
     }
 
     public boolean isAllowAnonymous() {
@@ -54,5 +64,9 @@ class BrokerConfiguration {
 
     public boolean isImmediateBufferFlush() {
         return immediateBufferFlush;
+    }
+
+    public boolean peerCertificateAsUsername() {
+        return peerCertificateAsUsername;
     }
 }

--- a/moquette-0.16/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/moquette-0.16/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -291,7 +291,7 @@ final class MQTTConnection {
             }
         }
 
-        if (brokerConfig.peerCertificateAsUsername()) {
+        if (brokerConfig.isPeerCertificateAsUsername()) {
             try {
                 // Use peer cert as username
                 SslHandler sslhandler = (SslHandler) channel.pipeline().get("ssl");

--- a/moquette-0.16/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/moquette-0.16/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -17,6 +17,7 @@ package io.moquette.broker;
 
 import io.moquette.broker.subscriptions.Topic;
 import io.moquette.broker.security.IAuthenticator;
+import io.moquette.broker.security.PemUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.Channel;
@@ -24,11 +25,15 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.mqtt.*;
+import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
 import java.net.InetSocketAddress;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -283,7 +288,21 @@ final class MQTTConnection {
                 LOG.info("Client didn't supply any password and MQTT anonymous mode is disabled CId={}", clientId);
                 return false;
             }
-            final String login = msg.payload().userName();
+            String login = msg.payload().userName();
+            if (brokerConfig.peerCertificateAsUsername()) {
+                try {
+                    // Use peer cert as username
+                    SslHandler sslhandler = (SslHandler) channel.pipeline().get("ssl");
+                    if (sslhandler != null) {
+                        Certificate[] certificateChain = sslhandler.engine().getSession().getPeerCertificates();
+                        login = PemUtils.certificatesToPem(certificateChain);
+                    }
+                } catch (SSLPeerUnverifiedException e) {
+                    // No peer cert provided
+                } catch (CertificateEncodingException e) {
+                    return false;
+                }
+            }
             if (!authenticator.checkValid(clientId, login, pwd)) {
                 LOG.info("Authenticator has rejected the MQTT credentials CId={}, username={}", clientId, login);
                 return false;

--- a/moquette-0.16/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/moquette-0.16/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -30,6 +30,7 @@ import io.netty.handler.timeout.IdleStateHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import java.net.InetSocketAddress;
 import java.security.cert.Certificate;
@@ -299,7 +300,7 @@ final class MQTTConnection {
                     }
                 } catch (SSLPeerUnverifiedException e) {
                     // No peer cert provided
-                } catch (CertificateEncodingException e) {
+                } catch (CertificateEncodingException|IOException e) {
                     return false;
                 }
             }

--- a/moquette-0.16/broker/src/main/java/io/moquette/broker/security/PemUtils.java
+++ b/moquette-0.16/broker/src/main/java/io/moquette/broker/security/PemUtils.java
@@ -20,7 +20,6 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.util.Base64;

--- a/moquette-0.16/broker/src/main/java/io/moquette/broker/security/PemUtils.java
+++ b/moquette-0.16/broker/src/main/java/io/moquette/broker/security/PemUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.moquette.broker.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.util.Base64;
+
+public final class PemUtils {
+    private static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
+    private static final String END_CERT = "-----END CERTIFICATE-----";
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
+    public static String certificatesToPem(Certificate... certificates) throws CertificateEncodingException {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (Certificate certificate : certificates) {
+            stringBuilder.append(certificateToPem(certificate));
+            stringBuilder.append(LINE_SEPARATOR);
+        }
+        return stringBuilder.toString();
+    }
+
+    private static String certificateToPem(Certificate certificate) throws CertificateEncodingException {
+        // Avoid pulling in a dependency for PEM encoding. X509 certificate are encoded as an ASN.1 DER.
+        // A PEM is just a base64 encoding of this, sandwiched between some text anchors
+        Base64.Encoder encoder = Base64.getMimeEncoder(64, LINE_SEPARATOR.getBytes(StandardCharsets.UTF_8));
+        String base64Der = encoder.encodeToString(certificate.getEncoded());
+        return String.join(LINE_SEPARATOR, BEGIN_CERT, base64Der, END_CERT);
+    }
+}

--- a/moquette-0.16/broker/src/test/java/io/moquette/broker/BrokerConfigurationTest.java
+++ b/moquette-0.16/broker/src/test/java/io/moquette/broker/BrokerConfigurationTest.java
@@ -33,6 +33,7 @@ public class BrokerConfigurationTest {
         assertFalse(brokerConfiguration.isAllowZeroByteClientId());
         assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertFalse(brokerConfiguration.isImmediateBufferFlush());
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
     }
 
     @Test
@@ -45,6 +46,7 @@ public class BrokerConfigurationTest {
         assertFalse(brokerConfiguration.isAllowZeroByteClientId());
         assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertFalse(brokerConfiguration.isImmediateBufferFlush());
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
     }
 
     @Test
@@ -57,6 +59,7 @@ public class BrokerConfigurationTest {
         assertTrue(brokerConfiguration.isAllowZeroByteClientId());
         assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertFalse(brokerConfiguration.isImmediateBufferFlush());
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
     }
 
     @Test
@@ -69,6 +72,7 @@ public class BrokerConfigurationTest {
         assertFalse(brokerConfiguration.isAllowZeroByteClientId());
         assertTrue(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertFalse(brokerConfiguration.isImmediateBufferFlush());
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
     }
 
     @Test
@@ -81,5 +85,19 @@ public class BrokerConfigurationTest {
         assertFalse(brokerConfiguration.isAllowZeroByteClientId());
         assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertTrue(brokerConfiguration.isImmediateBufferFlush());
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
+    }
+
+    @Test
+    public void configurePeerCertificateAsUsername() {
+        Properties properties = new Properties();
+        properties.put(BrokerConstants.PEER_CERTIFICATE_AS_USERNAME, "true");
+        MemoryConfig config = new MemoryConfig(properties);
+        BrokerConfiguration brokerConfiguration = new BrokerConfiguration(config);
+        assertTrue(brokerConfiguration.isAllowAnonymous());
+        assertFalse(brokerConfiguration.isAllowZeroByteClientId());
+        assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
+        assertFalse(brokerConfiguration.isImmediateBufferFlush());
+        assertTrue(brokerConfiguration.isPeerCertificateAsUsername());
     }
 }

--- a/moquette-0.16/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/moquette-0.16/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -15,20 +15,34 @@
  */
 package io.moquette.broker;
 
+import io.moquette.broker.security.PemUtils;
 import io.moquette.broker.security.PermitAllAuthorizatorPolicy;
 import io.moquette.broker.subscriptions.CTrieSubscriptionDirectory;
 import io.moquette.broker.subscriptions.ISubscriptionsDirectory;
 import io.moquette.broker.security.IAuthenticator;
 import io.moquette.persistence.MemorySubscriptionsRepository;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttVersion;
+import io.netty.handler.ssl.SslHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.util.HashMap;
 import java.util.concurrent.ExecutionException;
 
 import static io.moquette.broker.NettyChannelAssertions.assertEqualsConnAck;
@@ -39,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class MQTTConnectionConnectTest {
 
@@ -90,6 +105,17 @@ public class MQTTConnectionConnectTest {
 
     private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel, PostOffice postOffice) {
         return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);
+    }
+
+    private SslHandler createFakeSslHandler(Certificate peerCert) throws SSLPeerUnverifiedException {
+        SSLEngine mockSslEngine = mock(SSLEngine.class);
+        SslHandler sslHandler = new FakeSslHandler(mockSslEngine);
+
+        SSLSession mockSslSession = mock(SSLSession.class);
+        when(mockSslEngine.getSession()).thenReturn(mockSslSession);
+        when(mockSslSession.getPeerCertificates()).thenReturn(new Certificate[]{peerCert});
+
+        return sslHandler;
     }
 
     @Test
@@ -201,6 +227,57 @@ public class MQTTConnectionConnectTest {
         sut.processConnect(msg);
 
         // Verify
+        assertEqualsConnAck(CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD, channel.readOutbound());
+        assertFalse(channel.isOpen(), "Connection must be closed by the broker");
+    }
+
+    @Test
+    public void peerCertAsUsernameAuthentication() throws CertificateEncodingException, IOException, InterruptedException {
+        final byte[] PEER_CERT_BYTES = "PEER_CERT".getBytes(StandardCharsets.UTF_8);
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).build();
+        BrokerConfiguration config = new BrokerConfiguration(false, false, false, false, true);
+        Certificate peerCertificate = mock(Certificate.class);
+
+        // Add SslHandler to channel
+        sut = createMQTTConnection(config);
+        channel = (EmbeddedChannel) sut.channel;
+        channel.pipeline().addFirst("ssl", createFakeSslHandler(peerCertificate));
+
+        when(peerCertificate.getEncoded()).thenReturn(PEER_CERT_BYTES);
+        mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID),
+            singletonMap(PemUtils.certificatesToPem(peerCertificate), null));
+
+        // Exercise
+        final MQTTConnection sslConnection = createMQTTConnection(config, sut.channel, postOffice);
+        sslConnection.processConnect(msg);
+
+        // Verify
+        Thread.sleep(100);
+        assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
+        assertTrue(channel.isOpen(), "Connection is accepted and therefore must remain open");
+    }
+
+    @Test
+    public void peerCertAsUsernameAuthentication_badCert() throws CertificateEncodingException, IOException, InterruptedException {
+        final byte[] PEER_CERT_BYTES = "BAD_PEER_CERT".getBytes(StandardCharsets.UTF_8);
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).build();
+        BrokerConfiguration config = new BrokerConfiguration(false, false, false, false, true);
+        Certificate peerCertificate = mock(Certificate.class);
+
+        // Add SslHandler to channel
+        sut = createMQTTConnection(config);
+        channel = (EmbeddedChannel) sut.channel;
+        channel.pipeline().addFirst("ssl", createFakeSslHandler(peerCertificate));
+
+        when(peerCertificate.getEncoded()).thenReturn(PEER_CERT_BYTES);
+        mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID), new HashMap<>());
+
+        // Exercise
+        final MQTTConnection sslConnection = createMQTTConnection(config, sut.channel, postOffice);
+        sslConnection.processConnect(msg);
+
+        // Verify
+        Thread.sleep(100);
         assertEqualsConnAck(CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD, channel.readOutbound());
         assertFalse(channel.isOpen(), "Connection must be closed by the broker");
     }
@@ -329,6 +406,55 @@ public class MQTTConnectionConnectTest {
             int nextPacketId = sut.nextPacketId();
             assertTrue(nextPacketId > 0, "Packet ID must be > 0");
             assertTrue(nextPacketId <= 65_535, "Packet ID must be <= 65_535");
+        }
+    }
+
+    class FakeSslHandler extends SslHandler {
+        private ChannelOutboundHandlerAdapter outboundAdapter;
+
+        public FakeSslHandler(SSLEngine engine) {
+            super(engine);
+            outboundAdapter = new ChannelOutboundHandlerAdapter();
+        }
+
+        @Override
+        public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+            outboundAdapter.bind(ctx, localAddress, promise);
+        }
+
+        @Override
+        public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+            outboundAdapter.connect(ctx, remoteAddress, localAddress, promise);
+        }
+
+        @Override
+        public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+            outboundAdapter.deregister(ctx, promise);
+        }
+
+        @Override
+        public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+            outboundAdapter.disconnect(ctx, promise);
+        }
+
+        @Override
+        public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+            outboundAdapter.close(ctx, promise);
+        }
+
+        @Override
+        public void read(ChannelHandlerContext ctx) throws Exception {
+            outboundAdapter.read(ctx);
+        }
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            outboundAdapter.write(ctx, msg, promise);
+        }
+
+        @Override
+        public void flush(ChannelHandlerContext ctx) throws Exception {
+            outboundAdapter.flush(ctx);
         }
     }
 }

--- a/moquette-0.16/broker/src/test/java/io/moquette/broker/MockAuthenticator.java
+++ b/moquette-0.16/broker/src/test/java/io/moquette/broker/MockAuthenticator.java
@@ -43,10 +43,11 @@ public class MockAuthenticator implements IAuthenticator {
         if (!m_userPwds.containsKey(username)) {
             return false;
         }
-        if (password == null) {
-            return false;
+        if (password != null) {
+            return m_userPwds.get(username).equals(new String(password, UTF_8));
+        } else {
+            return m_userPwds.get(username) == null;
         }
-        return m_userPwds.get(username).equals(new String(password, UTF_8));
     }
 
 }


### PR DESCRIPTION
This change allows auth plugins to receive the client peer certificate as the
username during authorization calls.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**
This *should* be easier to maintain and upstream than the previous change which marshaled data into a `ClientData` class.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
