### PR TITLE
revert: bump h2 from 1.4.199 to 2.1.210 in /moquette…

### DIFF
--- a/moquette-0.16/broker/pom.xml
+++ b/moquette-0.16/broker/pom.xml
@@ -19,7 +19,7 @@
              https://github.com/netty/netty/blob/netty-4.1.73.Final/pom.xml#L545 -->
         <netty.tcnative.version>2.0.46.Final</netty.tcnative.version>
         <paho.version>1.2.5</paho.version>
-        <h2.version>2.1.210</h2.version>
+        <h2.version>1.4.199</h2.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
…-0.16/broker (#85)"

This reverts commit 22248da2d20c727031f510ad0d2f279759c13027.

**Issue #, if available:**

**Description of changes:**
Reverts H2 back to previous version. There are known security vulnerabilities in this older version. However, we do not use H2 in production so are not impacted.

**Why is this change necessary:**
There were significant interface changes between H2 1.4 and 2.1 which break. Moquette code must be updated before we can migrate to the latest major version.

**How was this change tested:**
Build succeeded

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
