### PR TITLE
chore: migrate to Moquette 0.16

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>io.moquette</groupId>
             <artifactId>moquette-broker</artifactId>
-            <version>0.14-gg</version>
+            <version>0.16-gg</version>
         </dependency>
     </dependencies>
     <build>

--- a/integration/src/main/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizer.java
+++ b/integration/src/main/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizer.java
@@ -11,7 +11,6 @@ import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.device.exception.AuthorizationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import io.moquette.broker.security.ClientData;
 import io.moquette.broker.security.IAuthenticator;
 import io.moquette.broker.security.IAuthorizatorPolicy;
 import io.moquette.broker.subscriptions.Topic;
@@ -20,7 +19,6 @@ import io.moquette.interception.InterceptHandler;
 import io.moquette.interception.messages.InterceptConnectionLostMessage;
 import io.moquette.interception.messages.InterceptDisconnectMessage;
 
-import java.security.cert.X509Certificate;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -46,16 +44,14 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
     }
 
     @Override
-    public boolean checkValid(ClientData clientData) {
-        if (!clientData.getCertificates().isPresent()) {
-            LOG.error("No certificate in client data");
+    public boolean checkValid(String clientId, String username, byte[] password) {
+        if (username == null || username.isEmpty()) {
+            LOG.error("No peer certificate provided");
             return false;
         }
-        X509Certificate[] certificateChain = (X509Certificate[]) clientData.getCertificates().get();
 
         // Retrieve session ID and construct authorization request for MQTT CONNECT
-        String sessionId = trustManager.getSessionForCertificate(certificateChain);
-        String clientId = clientData.getClientId();
+        String sessionId = trustManager.getSessionForCertificate(username);
         LOG.atInfo().kv(CLIENT_ID, clientId).kv(SESSION_ID, sessionId).log("Retrieved client session");
 
         try {

--- a/integration/src/main/java/com/aws/greengrass/mqttbroker/ClientDeviceTrustManager.java
+++ b/integration/src/main/java/com/aws/greengrass/mqttbroker/ClientDeviceTrustManager.java
@@ -70,9 +70,19 @@ public class ClientDeviceTrustManager implements X509TrustManager {
             return null;
         }
 
-        String sessionId = sessionMap.remove(certPem);
+        return getSessionForCertificate(certPem);
+    }
+
+    /**
+     * Returns a valid session ID for the given certificate chain, if it exists.
+     *
+     * @param certificatePem peer certificate PEM
+     * @return a session id
+     */
+    public String getSessionForCertificate(String certificatePem) {
+        String sessionId = sessionMap.remove(certificatePem);
         if (sessionId == null) {
-            sessionId = createSession(certPem);
+            sessionId = createSession(certificatePem);
         }
         return sessionId;
     }

--- a/integration/src/main/java/com/aws/greengrass/mqttbroker/GreengrassMoquetteSslContextCreator.java
+++ b/integration/src/main/java/com/aws/greengrass/mqttbroker/GreengrassMoquetteSslContextCreator.java
@@ -78,7 +78,7 @@ public class GreengrassMoquetteSslContextCreator implements ISslContextCreator {
                     return null;
             }
             // if client authentication is enabled a trustmanager needs to be added to the ServerContext
-            String needsClientAuth = props.getProperty(BrokerConstants.NEED_CLIENT_AUTH, "false");
+            String needsClientAuth = props.getProperty(BrokerConstants.NEED_CLIENT_AUTH, "true");
             if (Boolean.parseBoolean(needsClientAuth)) {
                 addClientAuthentication(ks, contextBuilder);
             }

--- a/integration/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
+++ b/integration/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
@@ -167,6 +167,7 @@ public class MQTTService extends PluginService {
         p.setProperty(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, password);
         p.setProperty(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, password);
         p.setProperty(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, "false");
+        p.setProperty(BrokerConstants.PEER_CERTIFICATE_AS_USERNAME, "true");
         p.setProperty(BrokerConstants.NEED_CLIENT_AUTH, "true");
         p.setProperty(BrokerConstants.IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME, "true");
         p.setProperty(BrokerConstants.NETTY_MAX_BYTES_PROPERTY_NAME, String.valueOf(Coerce

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     </licenses>
 
     <modules>
-        <module>moquette</module>
+        <module>moquette-0.16</module>
         <module>integration</module>
     </modules>
 </project>


### PR DESCRIPTION
This change migrates to the Moquette 0.16 branch. As part of this migration,
we're backing out changes to the Moquette authorization interface, and instead
are utilizing the peer_certificate_as_username option to receive client certs.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**
Requires #88 and #96

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
