### PR TITLE
DNM! moquette 0.16 dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,12 @@ jobs:
       - name: Build with Maven (not Windows)
         env:
             AWS_REGION: us-west-2
-        run: mvn -U -ntp verify
+        run: mvn -U -ntp verify -Dtest=ServerIntegrationOpenSSLTest
         if: matrix.os != 'windows-latest'
       - name: Build with Maven (Windows)
         env:
             AWS_REGION: us-west-2
-        run: mvn -U -ntp verify
+        run: mvn -U -ntp verify -Dtest=ServerIntegrationOpenSSLTest
         shell: cmd
         if: matrix.os == 'windows-latest'
       - name: Upload Failed Test Report

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 integration/target/**
+*.iml
+greengrass-build

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>io.moquette</groupId>
             <artifactId>moquette-broker</artifactId>
-            <version>0.14-gg</version>
+            <version>0.16-gg</version>
         </dependency>
     </dependencies>
     <build>

--- a/integration/src/main/java/com/aws/greengrass/mqttbroker/ClientDeviceTrustManager.java
+++ b/integration/src/main/java/com/aws/greengrass/mqttbroker/ClientDeviceTrustManager.java
@@ -70,9 +70,19 @@ public class ClientDeviceTrustManager implements X509TrustManager {
             return null;
         }
 
-        String sessionId = sessionMap.remove(certPem);
+        return getSessionForCertificate(certPem);
+    }
+
+    /**
+     * Returns a valid session ID for the given certificate chain, if it exists.
+     *
+     * @param certificatePem peer certificate PEM
+     * @return a session id
+     */
+    public String getSessionForCertificate(String certificatePem) {
+        String sessionId = sessionMap.remove(certificatePem);
         if (sessionId == null) {
-            sessionId = createSession(certPem);
+            sessionId = createSession(certificatePem);
         }
         return sessionId;
     }

--- a/integration/src/main/java/com/aws/greengrass/mqttbroker/GreengrassMoquetteSslContextCreator.java
+++ b/integration/src/main/java/com/aws/greengrass/mqttbroker/GreengrassMoquetteSslContextCreator.java
@@ -78,7 +78,7 @@ public class GreengrassMoquetteSslContextCreator implements ISslContextCreator {
                     return null;
             }
             // if client authentication is enabled a trustmanager needs to be added to the ServerContext
-            String needsClientAuth = props.getProperty(BrokerConstants.NEED_CLIENT_AUTH, "false");
+            String needsClientAuth = props.getProperty(BrokerConstants.NEED_CLIENT_AUTH, "true");
             if (Boolean.parseBoolean(needsClientAuth)) {
                 addClientAuthentication(ks, contextBuilder);
             }

--- a/integration/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
+++ b/integration/src/main/java/com/aws/greengrass/mqttbroker/MQTTService.java
@@ -166,7 +166,8 @@ public class MQTTService extends PluginService {
         p.setProperty(BrokerConstants.JKS_PATH_PROPERTY_NAME, brokerKeyStore.getJksPath());
         p.setProperty(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, password);
         p.setProperty(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, password);
-        p.setProperty(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, "false");
+        p.setProperty(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, "true");
+        p.setProperty(BrokerConstants.PEER_CERTIFICATE_AS_USERNAME, "true");
         p.setProperty(BrokerConstants.NEED_CLIENT_AUTH, "true");
         p.setProperty(BrokerConstants.IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME, "true");
         p.setProperty(BrokerConstants.NETTY_MAX_BYTES_PROPERTY_NAME, String.valueOf(Coerce

--- a/moquette-0.16/broker/pom.xml
+++ b/moquette-0.16/broker/pom.xml
@@ -14,10 +14,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- IMPORTANT: netty.version and netty.tcnative.version must be bumped together!
+             Check Netty pom.xm to know the right version of tcnative, for example
+             https://github.com/netty/netty/blob/netty-4.1.77.Final/pom.xml#L531 -->
         <netty.version>4.1.77.Final</netty.version>
-        <!-- Check Netty pom.xm to know the right version of tcnative, for example
-             https://github.com/netty/netty/blob/netty-4.1.73.Final/pom.xml#L545 -->
-        <netty.tcnative.version>2.0.46.Final</netty.tcnative.version>
+        <netty.tcnative.version>2.0.52.Final</netty.tcnative.version>
         <paho.version>1.2.5</paho.version>
         <h2.version>1.4.199</h2.version>
     </properties>

--- a/moquette-0.16/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/moquette-0.16/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -49,6 +49,7 @@ public final class BrokerConstants {
     public static final String KEY_STORE_PASSWORD_PROPERTY_NAME = "key_store_password";
     public static final String KEY_MANAGER_PASSWORD_PROPERTY_NAME = "key_manager_password";
     public static final String ALLOW_ANONYMOUS_PROPERTY_NAME = "allow_anonymous";
+    public static final String PEER_CERTIFICATE_AS_USERNAME = "peer_certificate_as_username";
     public static final String REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT = "reauthorize_subscriptions_on_connect";
     public static final String ALLOW_ZERO_BYTE_CLIENT_ID_PROPERTY_NAME = "allow_zero_byte_client_id";
     public static final String ACL_FILE_PROPERTY_NAME = "acl_file";

--- a/moquette-0.16/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
+++ b/moquette-0.16/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
@@ -24,20 +24,30 @@ class BrokerConfiguration {
     private final boolean allowZeroByteClientId;
     private final boolean reauthorizeSubscriptionsOnConnect;
     private final boolean immediateBufferFlush;
+    private final boolean peerCertificateAsUsername;
 
     BrokerConfiguration(IConfig props) {
         allowAnonymous = props.boolProp(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, true);
         allowZeroByteClientId = props.boolProp(BrokerConstants.ALLOW_ZERO_BYTE_CLIENT_ID_PROPERTY_NAME, false);
         reauthorizeSubscriptionsOnConnect = props.boolProp(BrokerConstants.REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT, false);
         immediateBufferFlush = props.boolProp(BrokerConstants.IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME, false);
+        peerCertificateAsUsername = props.boolProp(BrokerConstants.PEER_CERTIFICATE_AS_USERNAME, false);
     }
 
     public BrokerConfiguration(boolean allowAnonymous, boolean allowZeroByteClientId,
                                boolean reauthorizeSubscriptionsOnConnect, boolean immediateBufferFlush) {
+        this(allowAnonymous, allowZeroByteClientId,
+            reauthorizeSubscriptionsOnConnect, immediateBufferFlush, false);
+    }
+
+    public BrokerConfiguration(boolean allowAnonymous, boolean allowZeroByteClientId,
+                               boolean reauthorizeSubscriptionsOnConnect, boolean immediateBufferFlush,
+                               boolean peerCertificateAsUsername) {
         this.allowAnonymous = allowAnonymous;
         this.allowZeroByteClientId = allowZeroByteClientId;
         this.reauthorizeSubscriptionsOnConnect = reauthorizeSubscriptionsOnConnect;
         this.immediateBufferFlush = immediateBufferFlush;
+        this.peerCertificateAsUsername = peerCertificateAsUsername;
     }
 
     public boolean isAllowAnonymous() {
@@ -54,5 +64,9 @@ class BrokerConfiguration {
 
     public boolean isImmediateBufferFlush() {
         return immediateBufferFlush;
+    }
+
+    public boolean peerCertificateAsUsername() {
+        return peerCertificateAsUsername;
     }
 }

--- a/moquette-0.16/broker/src/main/java/io/moquette/broker/metrics/MQTTMessageLogger.java
+++ b/moquette-0.16/broker/src/main/java/io/moquette/broker/metrics/MQTTMessageLogger.java
@@ -107,12 +107,12 @@ public class MQTTMessageLogger extends ChannelDuplexHandler {
             case PUBREL:
             case PUBACK:
             case UNSUBACK:
-                LOG.info("{} {} <{}> packetID <{}>", direction, messageType, clientID, messageId(msg));
+                LOG.debug("{} {} <{}> packetID <{}>", direction, messageType, clientID, messageId(msg));
                 break;
             case SUBACK:
                 MqttSubAckMessage suback = (MqttSubAckMessage) msg;
                 final List<Integer> grantedQoSLevels = suback.payload().grantedQoSLevels();
-                LOG.info("{} SUBACK <{}> packetID <{}>, grantedQoses {}", direction, clientID, messageId(msg),
+                LOG.debug("{} SUBACK <{}> packetID <{}>, grantedQoses {}", direction, clientID, messageId(msg),
                     grantedQoSLevels);
                 break;
         }

--- a/moquette-0.16/broker/src/main/java/io/moquette/broker/security/PemUtils.java
+++ b/moquette-0.16/broker/src/main/java/io/moquette/broker/security/PemUtils.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.moquette.broker.security;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.util.Base64;
+
+public final class PemUtils {
+    private static final String certificateBoundaryType = "CERTIFICATE";
+
+    public static String certificatesToPem(Certificate... certificates)
+        throws CertificateEncodingException, IOException {
+        try (StringWriter str = new StringWriter();
+             PemWriter pemWriter = new PemWriter(str)) {
+            for (Certificate certificate : certificates) {
+                pemWriter.writeObject(certificateBoundaryType, certificate.getEncoded());
+            }
+            pemWriter.close();
+            return str.toString();
+        }
+    }
+
+    /**
+     * Copyright (c) 2000 - 2021 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+     * SPDX-License-Identifier: MIT
+     *
+     * <p>A generic PEM writer, based on RFC 1421
+     * From: https://javadoc.io/static/org.bouncycastle/bcprov-jdk15on/1.62/org/bouncycastle/util/io/pem/PemWriter.html</p>
+     */
+    public static class PemWriter extends BufferedWriter {
+        private static final int LINE_LENGTH = 64;
+        private final char[] buf = new char[LINE_LENGTH];
+        /**
+         * Base constructor.
+         *
+         * @param out output stream to use.
+         */
+        public PemWriter(Writer out) {
+            super(out);
+        }
+        /**
+         * Writes a pem encoded string.
+         *
+         * @param type  key type.
+         * @param bytes encoded string
+         * @throws IOException IO Exception
+         */
+        public void writeObject(String type, byte[] bytes) throws IOException {
+            writePreEncapsulationBoundary(type);
+            writeEncoded(bytes);
+            writePostEncapsulationBoundary(type);
+        }
+        private void writeEncoded(byte[] bytes) throws IOException {
+            bytes = Base64.getEncoder().encode(bytes);
+            for (int i = 0; i < bytes.length; i += buf.length) {
+                int index = 0;
+                while (index != buf.length) {
+                    if ((i + index) >= bytes.length) {
+                        break;
+                    }
+                    buf[index] = (char) bytes[i + index];
+                    index++;
+                }
+                this.write(buf, 0, index);
+                this.newLine();
+            }
+        }
+        private void writePreEncapsulationBoundary(String type) throws IOException {
+            this.write("-----BEGIN " + type + "-----");
+            this.newLine();
+        }
+        private void writePostEncapsulationBoundary(String type) throws IOException {
+            this.write("-----END " + type + "-----");
+            this.newLine();
+        }
+    }
+}

--- a/moquette-0.16/broker/src/test/java/io/moquette/integration/ServerIntegrationFuseTest.java
+++ b/moquette-0.16/broker/src/test/java/io/moquette/integration/ServerIntegrationFuseTest.java
@@ -103,8 +103,8 @@ public class ServerIntegrationFuseTest {
         // Exercise, kill the publisher connection
         m_publisher.kill();
 
-        // Verify, that the testament is fired
-        Message msg = m_subscriber.receive(1, TimeUnit.SECONDS); // wait the flush interval (1 sec)
+        // Verify, that the testament is fired (wait the flush interval (1 sec) + small buffer)
+        Message msg = m_subscriber.receive(1500, TimeUnit.MILLISECONDS);
         assertNotNull(msg, "We should get notified with 'Will' message");
         msg.ack();
         assertEquals(willTestamentMsg, new String(msg.getPayload(), UTF_8));

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     </licenses>
 
     <modules>
-        <module>moquette</module>
+        <module>moquette-0.16</module>
         <module>integration</module>
     </modules>
 </project>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

Tested using new "chaos tester". Memory stable after ~150M operations

```
************* CHAOS TESTER ************
** Performing 5000000 operations
** Spawning 32 threads
** 78 clients per thread
** 156250 operations per thread
** Start time: Sun May 22 18:49:33 2022
***************************************
*************** SUMMARY ***************
** End time:  Sun May 22 19:25:14 2022
** Connect Operations:    459195
**     Clean:             138153
**     Persistent:        321042
** Disonnect Operations:  459195
** Publish Operations:    2272014
** Subscribe Operations:  1816832
** Messages Received:    45937601
** Average Fanout:       20.218890
***************************************
```

Compared to current release which cannot handle the volume at all (continuous NPEs):

```
************* CHAOS TESTER ************
** Performing 10000 operations
** Spawning 32 threads
** 78 clients per thread
** 312 operations per thread
** Start time: Sun May 22 20:35:16 2022
***************************************
*************** SUMMARY ***************
** End time:  Sun May 22 20:35:54 2022
** Connect Operations:    12343
**     Clean:             3708
**     Persistent:        8635
** Disonnect Operations:  12343
** Publish Operations:    71
** Subscribe Operations:  48
** Messages Received:    6
** Average Fanout:       0.084507
***************************************
```

**Memory Usage:**
```
************* CHAOS TESTER ************
** Performing 100000 operations
** Spawning 32 threads
** 78 clients per thread
** 3125 operations per thread
** Start time: Sun May 22 21:03:52 2022
***************************************
```

Passing the peer certificate as username does not appear to increase memory usage over not doing that. I suspect the peer certificate is stored in memory anyway as part of the TLS stack, so additionally storing this as context within the `MQTTConnection` object isn't adding overhead.

As a crude measurement, I looked at system memory usage (htop) while running the chaos tester with the above parameters.

_Passing peer cert as username_: 1.03G -> 2.37G
_No certificate_: 1.06G -> 2.35G
_No certificate (rd 2)_: 991M -> 2.4G

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
