### PR TITLE
fix: bump netty.tcnative to match netty

### DIFF
--- a/moquette-0.16/broker/pom.xml
+++ b/moquette-0.16/broker/pom.xml
@@ -14,10 +14,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- IMPORTANT: netty.version and netty.tcnative.version must be bumped together!
+             Check Netty pom.xm to know the right version of tcnative, for example
+             https://github.com/netty/netty/blob/netty-4.1.77.Final/pom.xml#L531 -->
         <netty.version>4.1.77.Final</netty.version>
-        <!-- Check Netty pom.xm to know the right version of tcnative, for example
-             https://github.com/netty/netty/blob/netty-4.1.73.Final/pom.xml#L545 -->
-        <netty.tcnative.version>2.0.46.Final</netty.tcnative.version>
+        <netty.tcnative.version>2.0.52.Final</netty.tcnative.version>
         <paho.version>1.2.5</paho.version>
         <h2.version>1.4.199</h2.version>
     </properties>


### PR DESCRIPTION
OpenSSL tests broke after bumping netty version due to to a class not found
exception. Netty tcnative version must also be moved in lockstep.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
Verified that this succeeds on Github runner - https://github.com/aws-greengrass/aws-greengrass-moquette-mqtt/runs/6538236364 (failure is due to PMD, but relevant test passes)

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
