### PR TITLE
fix: close mvstore in unit tests

### DIFF
--- a/moquette-0.16/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
+++ b/moquette-0.16/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
@@ -46,6 +46,7 @@ public class H2PersistentQueueTest {
 
     @AfterEach
     public void tearDown() {
+        this.mvStore.close();
         File dbFile = new File(BrokerConstants.DEFAULT_PERSISTENT_PATH);
         if (dbFile.exists()) {
             dbFile.delete();


### PR DESCRIPTION
Failure to close the mvStore between test runs results in failures on
Windows due to locked files.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
