### PR TITLE
feat!: handle CDA session eviction

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<!--
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.aws.greengrass</groupId>
@@ -65,7 +71,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>client-devices-auth</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/integration/src/main/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizer.java
+++ b/integration/src/main/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizer.java
@@ -54,7 +54,7 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
             sessionPair = getSessionForClient(clientId, username);
             sessionId = sessionPair.getSession();
         } catch (AuthenticationException e) {
-            LOG.atWarn().kv(CLIENT_ID, clientId)
+            LOG.atWarn().cause(e).kv(CLIENT_ID, clientId)
                 .log("Can't create auth session. Check that the thing connects using its thing name as the "
                     + "client ID and has a valid AWS IoT client certificate.");
             return false;
@@ -81,7 +81,7 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
         try {
             canPerform = canDevicePerform(getSessionForClient(client, user), "mqtt:publish", resource);
         } catch (AuthenticationException e) {
-            LOG.atWarn().kv(CLIENT_ID, client).log("Unable to re-authenticate client.");
+            LOG.atWarn().cause(e).kv(CLIENT_ID, client).log("Unable to re-authenticate client.");
         }
         LOG.atDebug().kv("topic", topic).kv("isAllowed", canPerform).kv(CLIENT_ID, client)
             .log("MQTT publish request");
@@ -95,7 +95,7 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
         try {
             canPerform = canDevicePerform(getSessionForClient(client, user), "mqtt:subscribe", resource);
         } catch (AuthenticationException e) {
-            LOG.atWarn().kv(CLIENT_ID, client).log("Unable to re-authenticate client.");
+            LOG.atWarn().cause(e).kv(CLIENT_ID, client).log("Unable to re-authenticate client.");
         }
         LOG.atDebug().kv("topic", topic).kv("isAllowed", canPerform).kv(CLIENT_ID, client)
             .log("MQTT subscribe request");

--- a/integration/src/main/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizer.java
+++ b/integration/src/main/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizer.java
@@ -9,7 +9,6 @@ import com.aws.greengrass.device.AuthorizationRequest;
 import com.aws.greengrass.device.ClientDevicesAuthServiceApi;
 import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.device.exception.AuthorizationException;
-import com.aws.greengrass.device.exception.InvalidSessionException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import io.moquette.broker.security.IAuthenticator;

--- a/integration/src/test/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizerTest.java
+++ b/integration/src/test/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizerTest.java
@@ -6,34 +6,27 @@
 package com.aws.greengrass.mqttbroker;
 
 import com.aws.greengrass.device.AuthorizationRequest;
-import com.aws.greengrass.device.DeviceAuthClient;
+import com.aws.greengrass.device.ClientDevicesAuthServiceApi;
 import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.device.exception.AuthorizationException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
 import io.moquette.broker.subscriptions.Topic;
-import io.moquette.interception.messages.InterceptDisconnectMessage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.charset.StandardCharsets;
 
-import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.*;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
     @Mock
-    ClientDeviceTrustManager mockTrustManager;
-
-    @Mock
-    DeviceAuthClient mockDeviceAuthClient;
+    ClientDevicesAuthServiceApi mockClientDevicesAuthService;
 
     private static final String DEFAULT_SESSION = "SESSION_ID";
     private static final String DEFAULT_CLIENT = "clientId";
@@ -46,7 +39,7 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
         throws AuthorizationException {
         AuthorizationRequest authorizationRequest =
             AuthorizationRequest.builder().sessionId(session).operation(operation).resource(resource).build();
-        when(mockDeviceAuthClient.canDevicePerform(authorizationRequest)).thenReturn(doAllow);
+        when(mockClientDevicesAuthService.authorizeClientDeviceAction(authorizationRequest)).thenReturn(doAllow);
     }
 
     void configureConnectResponse(String session, String clientId, boolean doAllow) throws AuthorizationException {
@@ -75,79 +68,46 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_clientDataWithoutCertificate_WHEN_checkValid_THEN_returnsFalse() {
-        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockTrustManager, mockDeviceAuthClient);
+        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockClientDevicesAuthService);
         assertThat(authorizer.checkValid(DEFAULT_CLIENT, EMPTY_PEER_CERT, DEFAULT_PASSWORD), is(false));
     }
 
     @Test
-    void GIVEN_unauthorizedClient_WHEN_checkValid_THEN_returnsFalseAndClosesSession() throws Exception {
-        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockTrustManager, mockDeviceAuthClient);
+    void GIVEN_unauthorizedClient_WHEN_checkValid_THEN_returnsFalse() throws Exception {
+        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockClientDevicesAuthService);
 
-        when(mockTrustManager.getSessionForCertificate(DEFAULT_PEER_CERT)).thenReturn(DEFAULT_SESSION);
-        configureConnectResponse(false);
+        when(mockClientDevicesAuthService.getClientDeviceAuthToken(anyString(), anyMap())).thenThrow(
+            new AuthenticationException("Invalid client"));
 
         assertThat(authorizer.checkValid(DEFAULT_CLIENT, DEFAULT_PEER_CERT, DEFAULT_PASSWORD), is(false));
-        verify(mockDeviceAuthClient).attachThing(DEFAULT_SESSION, DEFAULT_CLIENT);
-        verify(mockDeviceAuthClient).closeSession(DEFAULT_SESSION);
-    }
-
-    @Test
-    void GIVEN_duplicateClientIds_WHEN_checkValid_THEN_firstSessionClosed() throws AuthorizationException {
-        final String USERNAME1 = "PeerCert1";
-        final String USERNAME2 = "PeerCert2";
-        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockTrustManager, mockDeviceAuthClient);
-
-        when(mockTrustManager.getSessionForCertificate(USERNAME1)).thenReturn("SESSION1");
-        configureConnectResponse("SESSION1", DEFAULT_CLIENT, true);
-        assertThat(authorizer.checkValid(DEFAULT_CLIENT, USERNAME1, DEFAULT_PASSWORD), is(true));
-        ClientDeviceAuthorizer.UserSessionPair pair = authorizer.getSessionForClient(DEFAULT_CLIENT, USERNAME1);
-        assertThat(pair.getSession(), is("SESSION1"));
-
-        when(mockTrustManager.getSessionForCertificate(USERNAME2)).thenReturn("SESSION2");
-        configureConnectResponse("SESSION2", DEFAULT_CLIENT, true);
-        assertThat(authorizer.checkValid(DEFAULT_CLIENT, USERNAME2, DEFAULT_PASSWORD), is(true));
-        assertThat(authorizer.getSessionForClient(DEFAULT_CLIENT, USERNAME1), is(nullValue()));
-        ClientDeviceAuthorizer.UserSessionPair pair2 = authorizer.getSessionForClient(DEFAULT_CLIENT, USERNAME2);
-        assertThat(pair2.getSession(), is("SESSION2"));
-
-        verify(mockDeviceAuthClient, atMostOnce()).closeSession("SESSION1");
     }
 
     @Test
     void GIVEN_authorizedClient_WHEN_checkValid_THEN_returnsTrue() throws Exception {
-        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockTrustManager, mockDeviceAuthClient);
+        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockClientDevicesAuthService);
 
-        when(mockTrustManager.getSessionForCertificate(DEFAULT_PEER_CERT)).thenReturn(DEFAULT_SESSION);
+        when(mockClientDevicesAuthService.getClientDeviceAuthToken(anyString(), anyMap())).thenReturn(DEFAULT_SESSION);
         configureConnectResponse(true);
 
         assertThat(authorizer.checkValid(DEFAULT_CLIENT, DEFAULT_PEER_CERT, DEFAULT_PASSWORD), is(true));
-        verify(mockDeviceAuthClient).attachThing(DEFAULT_SESSION, DEFAULT_CLIENT);
     }
 
     @Test
-    void GIVEN_attachThingThrowsException_WHEN_checkValid_THEN_returnsFalse(ExtensionContext context) throws Exception {
-        ignoreExceptionOfType(context, AuthenticationException.class);
-        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockTrustManager, mockDeviceAuthClient);
+    void GIVEN_unknownClient_WHEN_canReadCanWrite_THEN_returnsFalse() throws AuthenticationException {
+        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockClientDevicesAuthService);
 
-        when(mockTrustManager.getSessionForCertificate(DEFAULT_PEER_CERT)).thenReturn(DEFAULT_SESSION);
-        doThrow(AuthenticationException.class).when(mockDeviceAuthClient).attachThing(DEFAULT_SESSION, DEFAULT_CLIENT);
-
-        assertThat(authorizer.checkValid(DEFAULT_CLIENT, DEFAULT_PEER_CERT, DEFAULT_PASSWORD), is(false));
-    }
-
-    @Test
-    void GIVEN_unknownClient_WHEN_canReadCanWrite_THEN_returnsFalse() {
-        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockTrustManager, mockDeviceAuthClient);
+        when(mockClientDevicesAuthService.getClientDeviceAuthToken(anyString(), anyMap())).thenThrow(
+            new AuthenticationException("Invalid client"));
 
         assertThat(authorizer.canRead(Topic.asTopic(DEFAULT_TOPIC), "user", DEFAULT_CLIENT), is(false));
         assertThat(authorizer.canWrite(Topic.asTopic(DEFAULT_TOPIC), "user", DEFAULT_CLIENT), is(false));
     }
 
     @Test
-    void GIVEN_unauthorizedClient_WHEN_canReadCanWrite_THEN_returnsFalse() throws AuthorizationException {
-        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockTrustManager, mockDeviceAuthClient);
+    void GIVEN_unauthorizedClient_WHEN_canReadCanWrite_THEN_returnsFalse() throws AuthenticationException, AuthorizationException {
+        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockClientDevicesAuthService);
 
-        when(mockTrustManager.getSessionForCertificate(DEFAULT_PEER_CERT)).thenReturn(DEFAULT_SESSION);
+        when(mockClientDevicesAuthService.getClientDeviceAuthToken(anyString(), anyMap())).thenReturn(DEFAULT_SESSION);
         configureConnectResponse(true);
         configureSubscribeResponse(false);
         configurePublishResponse(false);
@@ -158,10 +118,10 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_unauthorizedClient_WHEN_canReadCanWrite_THEN_returnsTrue() throws AuthorizationException {
-        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockTrustManager, mockDeviceAuthClient);
+    void GIVEN_unauthorizedClient_WHEN_canReadCanWrite_THEN_returnsTrue() throws AuthenticationException, AuthorizationException {
+        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockClientDevicesAuthService);
 
-        when(mockTrustManager.getSessionForCertificate(DEFAULT_PEER_CERT)).thenReturn(DEFAULT_SESSION);
+        when(mockClientDevicesAuthService.getClientDeviceAuthToken(anyString(), anyMap())).thenReturn(DEFAULT_SESSION);
         configureConnectResponse(true);
         configureSubscribeResponse(true);
         configurePublishResponse(true);
@@ -173,8 +133,8 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_twoClientsWithDifferingPermissions_WHEN_canReadCanWrite_THEN_correctSessionIsUsed()
-        throws AuthorizationException {
-        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockTrustManager, mockDeviceAuthClient);
+        throws AuthenticationException, AuthorizationException {
+        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockClientDevicesAuthService);
         String session1 = "SESSION_ID1";
         String session2 = "SESSION_ID2";
         String client1 = "clientId1";
@@ -185,7 +145,6 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
         String topic2 = "topic/client2";
 
         // Client1 can connect and publish/subscribe on own topic, but not client2's topics
-        when(mockTrustManager.getSessionForCertificate(cert1)).thenReturn(session1);
         configureConnectResponse(session1, client1, true);
         configurePublishResponse(session1, topic1, true);
         configureSubscribeResponse(session1, topic1, true);
@@ -193,15 +152,17 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
         configureSubscribeResponse(session1, topic2, false);
 
         // Client2 can connect and publish/subscribe on own topic, but not client1's topics
-        when(mockTrustManager.getSessionForCertificate(cert2)).thenReturn(session2);
         configureConnectResponse(session2, client2, true);
         configurePublishResponse(session2, topic1, false);
         configureSubscribeResponse(session2, topic1, false);
         configurePublishResponse(session2, topic2, true);
         configureSubscribeResponse(session2, topic2, true);
 
+        when(mockClientDevicesAuthService.getClientDeviceAuthToken(anyString(), anyMap())).thenReturn(session1);
         assertThat(authorizer.checkValid(client1, cert1, DEFAULT_PASSWORD), is(true));
+        when(mockClientDevicesAuthService.getClientDeviceAuthToken(anyString(), anyMap())).thenReturn(session2);
         assertThat(authorizer.checkValid(client2, cert2, DEFAULT_PASSWORD), is(true));
+
         assertThat(authorizer.canRead(Topic.asTopic(topic1), cert1, client1), is(true));
         assertThat(authorizer.canWrite(Topic.asTopic(topic1), cert1, client1), is(true));
         assertThat(authorizer.canRead(Topic.asTopic(topic2), cert1, client1), is(false));
@@ -210,37 +171,5 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
         assertThat(authorizer.canWrite(Topic.asTopic(topic1), cert2, client2), is(false));
         assertThat(authorizer.canRead(Topic.asTopic(topic2), cert2, client2), is(true));
         assertThat(authorizer.canWrite(Topic.asTopic(topic2), cert2, client2), is(true));
-    }
-
-    @Test
-    void GIVEN_authorizedClient_WHEN_onDisconnect_THEN_closeCDASession() throws AuthorizationException {
-        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockTrustManager, mockDeviceAuthClient);
-
-        when(mockTrustManager.getSessionForCertificate(DEFAULT_PEER_CERT)).thenReturn(DEFAULT_SESSION);
-        configureConnectResponse(true);
-
-        assertThat(authorizer.checkValid(DEFAULT_CLIENT, DEFAULT_PEER_CERT, DEFAULT_PASSWORD), is(true));
-
-        authorizer.new ConnectionTerminationListener()
-            .onDisconnect(new InterceptDisconnectMessage(DEFAULT_CLIENT, DEFAULT_PEER_CERT));
-        verify(mockDeviceAuthClient).closeSession(DEFAULT_SESSION);
-        assertThat(authorizer.getSessionForClient(DEFAULT_CLIENT, DEFAULT_PEER_CERT), nullValue());
-    }
-
-    @Test
-    void GIVEN_authorizedClient_WHEN_onDisconnect_and_sessionAlreadyClosed_THEN_failSafe()
-        throws AuthorizationException {
-        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockTrustManager, mockDeviceAuthClient);
-
-        when(mockTrustManager.getSessionForCertificate(DEFAULT_PEER_CERT)).thenReturn(DEFAULT_SESSION);
-        configureConnectResponse(true);
-        doThrow(AuthorizationException.class).when(mockDeviceAuthClient).closeSession(DEFAULT_SESSION);
-
-        assertThat(authorizer.checkValid(DEFAULT_CLIENT, DEFAULT_PEER_CERT, DEFAULT_PASSWORD), is(true));
-
-        authorizer.new ConnectionTerminationListener()
-            .onDisconnect(new InterceptDisconnectMessage(DEFAULT_CLIENT, DEFAULT_PEER_CERT));
-        verify(mockDeviceAuthClient).closeSession(DEFAULT_SESSION);
-        assertThat(authorizer.getSessionForClient(DEFAULT_CLIENT, DEFAULT_PEER_CERT), nullValue());
     }
 }

--- a/integration/src/test/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizerTest.java
+++ b/integration/src/test/java/com/aws/greengrass/mqttbroker/ClientDeviceAuthorizerTest.java
@@ -14,11 +14,13 @@ import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
 import io.moquette.broker.subscriptions.Topic;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.charset.StandardCharsets;
 
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.*;
@@ -73,7 +75,10 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_unauthorizedClient_WHEN_checkValid_THEN_returnsFalse() throws Exception {
+    void GIVEN_unauthorizedClient_WHEN_checkValid_THEN_returnsFalse(ExtensionContext context)
+        throws AuthenticationException {
+        ignoreExceptionOfType(context, AuthenticationException.class);
+
         ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockClientDevicesAuthService);
 
         when(mockClientDevicesAuthService.getClientDeviceAuthToken(anyString(), anyMap())).thenThrow(
@@ -93,7 +98,10 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_unknownClient_WHEN_canReadCanWrite_THEN_returnsFalse() throws AuthenticationException {
+    void GIVEN_unknownClient_WHEN_canReadCanWrite_THEN_returnsFalse(ExtensionContext context)
+        throws AuthenticationException {
+        ignoreExceptionOfType(context, AuthenticationException.class);
+
         ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockClientDevicesAuthService);
 
         when(mockClientDevicesAuthService.getClientDeviceAuthToken(anyString(), anyMap())).thenThrow(

--- a/integration/src/test/java/com/aws/greengrass/mqttbroker/ClientDeviceTrustManagerTest.java
+++ b/integration/src/test/java/com/aws/greengrass/mqttbroker/ClientDeviceTrustManagerTest.java
@@ -5,7 +5,7 @@
 
 package com.aws.greengrass.mqttbroker;
 
-import com.aws.greengrass.device.DeviceAuthClient;
+import com.aws.greengrass.device.ClientDevicesAuthServiceApi;
 import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.security.cert.CertificateEncodingException;
@@ -22,13 +21,8 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class ClientDeviceTrustManagerTest extends GGServiceTestUtil {
@@ -36,12 +30,12 @@ public class ClientDeviceTrustManagerTest extends GGServiceTestUtil {
     X509Certificate mockCertificate;
 
     @Mock
-    DeviceAuthClient mockDeviceAuthClient;
+    ClientDevicesAuthServiceApi mockClientDevicesAuthService;
 
     @Test
     void GIVEN_nonEncodableCertificate_WHEN_checkClientTrusted_THEN_CertificateExceptionThrown() throws Exception {
         when(mockCertificate.getEncoded()).thenThrow(new CertificateEncodingException("Couldn't encode certificate"));
-        ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockDeviceAuthClient);
+        ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockClientDevicesAuthService);
         Assertions.assertThrows(CertificateException.class,
             () -> trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate}, "RSA"));
     }
@@ -49,74 +43,17 @@ public class ClientDeviceTrustManagerTest extends GGServiceTestUtil {
     @Test
     void GIVEN_encodableCertificate_WHEN_checkClientTrust_THEN_noExceptionThrown() throws Exception {
         when(mockCertificate.getEncoded()).thenReturn(new byte[]{0});
-        when(mockDeviceAuthClient.createSession(anyString())).thenReturn("session_id");
-        ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockDeviceAuthClient);
+        when(mockClientDevicesAuthService.verifyClientDeviceIdentity(anyString())).thenReturn(true);
+        ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockClientDevicesAuthService);
         trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate}, "RSA");
     }
 
     @Test
-    void GIVEN_unauthenticatedCertificate_WHEN_checkClientTrust_THEN_CertificateExceptionThrown(
-        ExtensionContext context) throws Exception {
-        ignoreExceptionOfType(context, AuthenticationException.class);
+    void GIVEN_unauthenticatedCertificate_WHEN_checkClientTrust_THEN_CertificateExceptionThrown() throws Exception {
         when(mockCertificate.getEncoded()).thenReturn(new byte[]{0});
-        when(mockDeviceAuthClient.createSession(anyString())).thenThrow(AuthenticationException.class);
-        ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockDeviceAuthClient);
+        when(mockClientDevicesAuthService.verifyClientDeviceIdentity(anyString())).thenReturn(false);
+        ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockClientDevicesAuthService);
         Assertions.assertThrows(CertificateException.class,
             () -> trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate}, "RSA"));
-    }
-
-    @Test
-    void GIVEN_singleConnection_WHEN_getSessionForCertificate_THEN_sessionCreatedAndReturned() throws Exception {
-        when(mockCertificate.getEncoded()).thenReturn(new byte[]{0});
-        when(mockDeviceAuthClient.createSession(anyString())).thenReturn("SESSION-ID");
-        ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockDeviceAuthClient);
-
-        // Session should be created when checking if certificate is trusted
-        trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate}, "RSA");
-        verify(mockDeviceAuthClient, times(1)).createSession(anyString());
-
-        // Session should be retrievable without creating additional session
-        reset(mockDeviceAuthClient);
-        assertThat(trustManager.getSessionForCertificate(new X509Certificate[]{mockCertificate}), is("SESSION-ID"));
-        verify(mockDeviceAuthClient, times(0)).createSession(anyString());
-    }
-
-    @Test
-    void GIVEN_twoConnectionsWithSameCert_WHEN_getSessionForCertificate_THEN_sessionIsCreatedOnDemand()
-        throws Exception {
-        when(mockCertificate.getEncoded()).thenReturn(new byte[]{0});
-        when(mockDeviceAuthClient.createSession(anyString())).thenReturn("SESSION-ID");
-
-        // Two calls to checkClientTrusted should only result in 1 session being created
-        ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockDeviceAuthClient);
-        trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate}, "RSA");
-        trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate}, "RSA");
-        verify(mockDeviceAuthClient, times(1)).createSession(anyString());
-
-        // Reset mock to return new session ID
-        when(mockDeviceAuthClient.createSession(anyString())).thenReturn("SESSION-ID2");
-
-        // A second session should be created after the first is retrieved
-        assertThat(trustManager.getSessionForCertificate(new X509Certificate[]{mockCertificate}), is("SESSION-ID"));
-        assertThat(trustManager.getSessionForCertificate(new X509Certificate[]{mockCertificate}), is("SESSION-ID2"));
-        verify(mockDeviceAuthClient, times(2)).createSession(anyString());
-    }
-
-    @Test
-    void GIVEN_twoConnectionsWithUniqueCerts_WHEN_checkClientTrusted_THEN_twoSessionsCreated() throws Exception {
-        X509Certificate mockCertificate2 = Mockito.mock(X509Certificate.class);
-        when(mockCertificate.getEncoded()).thenReturn(new byte[]{0});
-        when(mockCertificate2.getEncoded()).thenReturn(new byte[]{1});
-
-        // Two connections with different certificates should result in two sessions
-        ClientDeviceTrustManager trustManager = new ClientDeviceTrustManager(mockDeviceAuthClient);
-        when(mockDeviceAuthClient.createSession(anyString())).thenReturn("SESSION-ID");
-        trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate}, "RSA");
-        when(mockDeviceAuthClient.createSession(anyString())).thenReturn("SESSION-ID2");
-        trustManager.checkClientTrusted(new X509Certificate[]{mockCertificate2}, "RSA");
-        verify(mockDeviceAuthClient, times(2)).createSession(anyString());
-
-        assertThat(trustManager.getSessionForCertificate(new X509Certificate[]{mockCertificate}), is("SESSION-ID"));
-        assertThat(trustManager.getSessionForCertificate(new X509Certificate[]{mockCertificate2}), is("SESSION-ID2"));
     }
 }

--- a/integration/src/test/java/com/aws/greengrass/mqttbroker/ClientDeviceTrustManagerTest.java
+++ b/integration/src/test/java/com/aws/greengrass/mqttbroker/ClientDeviceTrustManagerTest.java
@@ -6,13 +6,11 @@
 package com.aws.greengrass.mqttbroker;
 
 import com.aws.greengrass.device.ClientDevicesAuthServiceApi;
-import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -20,7 +18,6 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
-import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.aws.greengrass</groupId>
     <artifactId>moquette-mqtt-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <licenses>

--- a/recipe.json
+++ b/recipe.json
@@ -6,7 +6,7 @@
   "ComponentPublisher": "AWS",
   "ComponentDependencies": {
     "aws.greengrass.clientdevices.Auth": {
-      "VersionRequirement": ">=2.0.0 <2.2.0",
+      "VersionRequirement": ">=2.2.0 <2.3.0",
       "DependencyType": "HARD"
     }
   },


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds logic to properly handle CDA session eviction by re-creating sessions when authZ calls fail due to `AuthenticationException`. This change also removes the coupling between Authenticator and Authorizer classes.

BREAKING CHANGE: This change requires APIs introduced in CDA 2.2 and breaks compatibility with previous versions.

**Why is this change necessary:**
Starting with CDA 2.2, it is now possible for auth sessions to be evicted, which will result in authZ failures unless Moquette attempts to re-create sessions.

**How was this change tested:**
Unit tests. Manual tests with CDA 2.2

**Any additional information or context required to review the change:**
Depends on:
* https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/91
* https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/92

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
