### PR TITLE
chore: use new subscribeToCertificateUpdates API

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -58,13 +58,13 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.2.0-SNAPSHOT</version>
+            <version>2.6.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.2.0-SNAPSHOT</version>
+            <version>2.6.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/integration/src/main/java/com/aws/greengrass/mqttbroker/BrokerKeyStore.java
+++ b/integration/src/main/java/com/aws/greengrass/mqttbroker/BrokerKeyStore.java
@@ -75,6 +75,7 @@ public class BrokerKeyStore {
      * @throws KeyStoreException If unable to set key entry.
      */
     public void updateServerCertificate(CertificateUpdateEvent certificateUpdate) throws KeyStoreException {
+        // TODO: Support certificate chains
         Certificate[] certChain = {certificateUpdate.getCertificate()};
         jks.setKeyEntry(BROKER_KEY_ALIAS, certificateUpdate.getKeyPair().getPrivate(), jksPassword.toCharArray(),
             certChain);

--- a/integration/src/main/java/com/aws/greengrass/mqttbroker/BrokerKeyStore.java
+++ b/integration/src/main/java/com/aws/greengrass/mqttbroker/BrokerKeyStore.java
@@ -5,40 +5,26 @@
 
 package com.aws.greengrass.mqttbroker;
 
-import com.aws.greengrass.certificatemanager.certificate.CertificateRequestGenerator;
+import com.aws.greengrass.device.api.CertificateUpdateEvent;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Utils;
 import lombok.Getter;
-import org.bouncycastle.operator.OperatorCreationException;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.Inet4Address;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
 
 public class BrokerKeyStore {
     private static final Logger LOGGER = LogManager.getLogger(BrokerKeyStore.class);
-    private static final String DEFAULT_BROKER_CN = MQTTService.SERVICE_NAME;
     private static final String KEYSTORE_FILE_NAME = "keystore.jks";
     private static final String BROKER_KEY_ALIAS = "pk";
 
@@ -48,7 +34,6 @@ public class BrokerKeyStore {
     @Getter
     private final String jksPassword;
     private KeyStore jks;
-    private KeyPair jksKeyPair;
 
     /**
      * MQTTBrokerKeyStore constructor.
@@ -73,15 +58,6 @@ public class BrokerKeyStore {
      * @throws KeyStoreException Unable to initialize KeyStore.
      */
     public void initialize() throws KeyStoreException {
-        // Initialize new keystore rather than loading an old one
-        try {
-            KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-            kpg.initialize(2048);
-            jksKeyPair = kpg.generateKeyPair();
-        } catch (NoSuchAlgorithmException e) {
-            throw new KeyStoreException("Unable to generate keypair for broker key store", e);
-        }
-
         KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         try {
             ks.load(null, jksPassword.toCharArray());
@@ -93,43 +69,15 @@ public class BrokerKeyStore {
     }
 
     /**
-     * Generate CSR from KeyStore private key.
-     *
-     * @return PEM encoded CSR string
-     * @throws IOException               IOException
-     * @throws OperatorCreationException OperatorCreationException
-     */
-    public String getCsr() throws IOException, OperatorCreationException {
-        return CertificateRequestGenerator.createCSR(jksKeyPair, DEFAULT_BROKER_CN, getHostIpAddresses(),
-            new ArrayList<>(Arrays.asList("localhost")));
-    }
-
-    //TODO delete me after beta release
-    private List<InetAddress> getHostIpAddresses() throws SocketException {
-        List<InetAddress> ipAddresses = new ArrayList<>();
-        Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
-        while (networkInterfaces.hasMoreElements()) {
-            NetworkInterface ni = networkInterfaces.nextElement();
-            Enumeration<InetAddress> inetAddresses = ni.getInetAddresses();
-            while (inetAddresses.hasMoreElements()) {
-                InetAddress inetAddress = inetAddresses.nextElement();
-                if (inetAddress instanceof Inet4Address) {
-                    ipAddresses.add(inetAddress);
-                }
-            }
-        }
-        return Collections.unmodifiableList(ipAddresses);
-    }
-
-    /**
      * Update KeyStore key certificate.
      *
-     * @param certificate Updated certificate
+     * @param certificateUpdate Updated certificate
      * @throws KeyStoreException If unable to set key entry.
      */
-    public void updateServerCertificate(X509Certificate certificate) throws KeyStoreException {
-        Certificate[] certChain = {certificate};
-        jks.setKeyEntry(BROKER_KEY_ALIAS, jksKeyPair.getPrivate(), jksPassword.toCharArray(), certChain);
+    public void updateServerCertificate(CertificateUpdateEvent certificateUpdate) throws KeyStoreException {
+        Certificate[] certChain = {certificateUpdate.getCertificate()};
+        jks.setKeyEntry(BROKER_KEY_ALIAS, certificateUpdate.getKeyPair().getPrivate(), jksPassword.toCharArray(),
+            certChain);
 
         try {
             commit();

--- a/integration/src/test/java/com/aws/greengrass/mqttbroker/MQTTServiceTest.java
+++ b/integration/src/test/java/com/aws/greengrass/mqttbroker/MQTTServiceTest.java
@@ -52,6 +52,9 @@ public class MQTTServiceTest extends GGServiceTestUtil {
 
     @BeforeEach
     void setup() {
+        // Set this property for kernel to scan its own classpath to find plugins
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
+
         kernel = new Kernel();
         kernel.getContext().put(ClientDevicesAuthServiceApi.class, mockCDAServiceApi);
     }

--- a/integration/src/test/java/com/aws/greengrass/mqttbroker/MQTTServiceTest.java
+++ b/integration/src/test/java/com/aws/greengrass/mqttbroker/MQTTServiceTest.java
@@ -5,9 +5,10 @@
 
 package com.aws.greengrass.mqttbroker;
 
-import com.aws.greengrass.certificatemanager.CertificateManager;
-import com.aws.greengrass.certificatemanager.certificate.CsrProcessingException;
 import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.device.ClientDevicesAuthServiceApi;
+import com.aws.greengrass.device.api.GetCertificateRequest;
+import com.aws.greengrass.device.exception.CertificateGenerationException;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
@@ -26,18 +27,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.file.Path;
-import java.security.KeyStoreException;
-import java.security.cert.X509Certificate;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
@@ -51,12 +48,12 @@ public class MQTTServiceTest extends GGServiceTestUtil {
     private Kernel kernel;
 
     @Mock
-    CertificateManager mockCertificateManager;
+    ClientDevicesAuthServiceApi mockCDAServiceApi;
 
     @BeforeEach
     void setup() {
         kernel = new Kernel();
-        kernel.getContext().put(CertificateManager.class, mockCertificateManager);
+        kernel.getContext().put(ClientDevicesAuthServiceApi.class, mockCDAServiceApi);
     }
 
     @AfterEach
@@ -86,17 +83,17 @@ public class MQTTServiceTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_defaultConfig_WHEN_startComponent_THEN_brokerStartsOnPort8883_and_subscriptions_dont_duplicate()
-        throws InterruptedException, ServiceLoadException, CsrProcessingException, KeyStoreException {
+        throws InterruptedException, ServiceLoadException, CertificateGenerationException {
         startNucleusWithConfig("config.yaml");
-        ArgumentCaptor<Consumer<X509Certificate>> captor = ArgumentCaptor.forClass(Consumer.class);
-        Mockito.doNothing().when(mockCertificateManager).subscribeToServerCertificateUpdates(anyString(), captor.capture());
-        verify(mockCertificateManager, timeout(5_000).times(1)).subscribeToServerCertificateUpdates(any(), any());
+        ArgumentCaptor<GetCertificateRequest> captor = ArgumentCaptor.forClass(GetCertificateRequest.class);
+        Mockito.doNothing().when(mockCDAServiceApi).subscribeToCertificateUpdates(any());
+        verify(mockCDAServiceApi, timeout(5_000).times(1)).subscribeToCertificateUpdates(captor.capture());
         kernel.locate(MQTTService.SERVICE_NAME).requestRestart();
-        verify(mockCertificateManager, timeout(5_000).times(2)).subscribeToServerCertificateUpdates(any(), any());
+        verify(mockCDAServiceApi, timeout(5_000).times(2)).subscribeToCertificateUpdates(any());
         kernel.locate(MQTTService.SERVICE_NAME).requestRestart();
-        verify(mockCertificateManager, timeout(5_000).times(3)).subscribeToServerCertificateUpdates(any(), any());
+        verify(mockCDAServiceApi, timeout(5_000).times(3)).subscribeToCertificateUpdates(any());
         kernel.locate(MQTTService.SERVICE_NAME).requestRestart();
-        verify(mockCertificateManager, timeout(5_000).times(4)).subscribeToServerCertificateUpdates(any(), any());
+        verify(mockCDAServiceApi, timeout(5_000).times(4)).subscribeToCertificateUpdates(any());
         Thread.sleep(1_000);
 
         assertThat(isListeningOnPort(8883), is(true));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Removes CSR generation logic for getting server certificates and instead uses the subscribeToCertificateUpdates API

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**
Depends on https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/95
CI will fail until the above is merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
