### PR TITLE
feat: emit mqtt metrics

### DIFF
--- a/integration/src/main/java/com/aws/greengrass/mqtt/moquette/metrics/MoquetteMqttMetricsEmmitter.java
+++ b/integration/src/main/java/com/aws/greengrass/mqtt/moquette/metrics/MoquetteMqttMetricsEmmitter.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqtt.moquette.metrics;
+
+import com.aws.greengrass.telemetry.impl.Metric;
+import com.aws.greengrass.telemetry.impl.MetricFactory;
+import com.aws.greengrass.telemetry.models.TelemetryAggregation;
+import com.aws.greengrass.telemetry.models.TelemetryUnit;
+import io.moquette.interception.AbstractInterceptHandler;
+import io.moquette.interception.InterceptHandler;
+import io.moquette.interception.messages.InterceptConnectMessage;
+import io.moquette.interception.messages.InterceptDisconnectMessage;
+import io.moquette.interception.messages.InterceptPublishMessage;
+import io.moquette.interception.messages.InterceptSubscribeMessage;
+import io.moquette.interception.messages.InterceptUnsubscribeMessage;
+
+import java.time.Instant;
+
+public class MoquetteMqttMetricsEmmitter {
+
+    private final MetricFactory metricFactory = new MetricFactory(MqttMetrics.MOQUETTE_MQTT_NAMESPACE);
+
+    /**
+     * Emits Moquette MQTT metrics.
+     *
+     * @param metric {@link Metric} to be emitted in Moquette MQTT namespace
+     */
+    public void emitMetric(Metric metric) {
+        metricFactory.putMetricData(metric);
+    }
+
+    public class MqttMetricsCaptor extends AbstractInterceptHandler implements InterceptHandler {
+
+        @Override
+        public String getID() {
+            return "MoquetteMqttMetricsCaptor";
+        }
+
+        @Override
+        public void onConnect(InterceptConnectMessage msg) {
+            emitMetric(Metric.builder()
+                .namespace(MqttMetrics.MOQUETTE_MQTT_NAMESPACE)
+                .name(MqttMetrics.CONNECT_SUCCESS)
+                .unit(TelemetryUnit.Count)
+                .aggregation(TelemetryAggregation.Sum)
+                .value(1)
+                .timestamp(Instant.now().toEpochMilli())
+                .build());
+        }
+
+        @Override
+        public void onDisconnect(InterceptDisconnectMessage msg) {
+            emitMetric(Metric.builder()
+                .namespace(MqttMetrics.MOQUETTE_MQTT_NAMESPACE)
+                .name(MqttMetrics.DISCONNECT)
+                .unit(TelemetryUnit.Count)
+                .aggregation(TelemetryAggregation.Sum)
+                .value(1)
+                .timestamp(Instant.now().toEpochMilli())
+                .build());
+        }
+
+        @Override
+        public void onPublish(InterceptPublishMessage msg) {
+            emitMetric(Metric.builder()
+                .namespace(MqttMetrics.MOQUETTE_MQTT_NAMESPACE)
+                .name(MqttMetrics.PUBLISH_OUT_SUCCESS)
+                .unit(TelemetryUnit.Count)
+                .aggregation(TelemetryAggregation.Sum)
+                .value(1)
+                .timestamp(Instant.now().toEpochMilli())
+                .build());
+        }
+
+        @Override
+        public void onSubscribe(InterceptSubscribeMessage msg) {
+            emitMetric(Metric.builder()
+                .namespace(MqttMetrics.MOQUETTE_MQTT_NAMESPACE)
+                .name(MqttMetrics.SUBSCRIBE_SUCCESS)
+                .unit(TelemetryUnit.Count)
+                .aggregation(TelemetryAggregation.Sum)
+                .value(1)
+                .timestamp(Instant.now().toEpochMilli())
+                .build());
+        }
+
+        @Override
+        public void onUnsubscribe(InterceptUnsubscribeMessage msg) {
+            emitMetric(Metric.builder()
+                .namespace(MqttMetrics.MOQUETTE_MQTT_NAMESPACE)
+                .name(MqttMetrics.UNSUBSCRIBE)
+                .unit(TelemetryUnit.Count)
+                .aggregation(TelemetryAggregation.Sum)
+                .value(1)
+                .timestamp(Instant.now().toEpochMilli())
+                .build());
+        }
+    }
+}

--- a/integration/src/main/java/com/aws/greengrass/mqtt/moquette/metrics/MqttMetrics.java
+++ b/integration/src/main/java/com/aws/greengrass/mqtt/moquette/metrics/MqttMetrics.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqtt.moquette.metrics;
+
+
+public final class MqttMetrics {
+    public static final String MOQUETTE_MQTT_NAMESPACE = "MoquetteMqtt";
+    public static final String CONNECT_SUCCESS = "Connect.Success";
+    public static final String CONNECT_AUTH_ERROR = "Connect.AuthError";
+    public static final String SUBSCRIBE_SUCCESS = "Subscribe.Success";
+    public static final String SUBSCRIBE_AUTH_ERROR = "Subscribe.AuthError";
+    public static final String PUBLISH_OUT_SUCCESS = "PublishOut.Success";
+    public static final String PUBLISH_IN_AUTH_ERROR = "PublishIn.AuthError";
+    public static final String DISCONNECT = "Disconnect";
+    public static final String UNSUBSCRIBE = "Unsubscribe";
+    public static final String UNKNOWN_AUTH_ERROR = "UnknownAuthError";
+}


### PR DESCRIPTION
**Description of changes:** 
- Emits MQTT metrics similar to  the message-broker metrics published by IoT Core: https://docs.aws.amazon.com/iot/latest/developerguide/metrics_dimensions.html#message-broker-metrics
```
1. Connect.Success : Number of successful client connections
2. Connect.AuthError: The number of connection requests that could not be authorized by the broker
3. Subscribe.Success: Number of successful client subscriptions
4. Subscribe.AuthError: The number of subscription requests that could not be authorized by the broker
5. PublishOut.Success: The number of messages successfully published by the broker
6. PublishIn.AuthError: The number of publish requests that could not be authorized by the broker
7. Disconnect: Number of successful client disconnects
8. Unsubscribe: Number of successful client unsubscribe
```

**How was this change tested:** `mvn clean package` with existing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
