### PR TITLE
feat: include full certificate chain

### DIFF
--- a/integration/src/main/java/com/aws/greengrass/mqtt/moquette/BrokerKeyStore.java
+++ b/integration/src/main/java/com/aws/greengrass/mqtt/moquette/BrokerKeyStore.java
@@ -22,9 +22,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Stream;
 
 public class BrokerKeyStore {
     private static final Logger LOGGER = LogManager.getLogger(BrokerKeyStore.class);
@@ -78,17 +76,12 @@ public class BrokerKeyStore {
      * @throws KeyStoreException If unable to set key entry.
      */
     public void updateServerCertificate(CertificateUpdateEvent certificateUpdate) throws KeyStoreException {
-        List<X509Certificate> certChainList = new ArrayList<>();
-        // Add server cert as first entry to the certificate chain
-        certChainList.add(certificateUpdate.getCertificate());
-        // Add rest of the CA certificate chain
-        certChainList.addAll(Arrays.asList(certificateUpdate.getCaCertificates()));
+        X509Certificate[] fullChain = Stream.concat(Stream.of(certificateUpdate.getCertificate()),
+                Stream.of(certificateUpdate.getCaCertificates()))
+            .toArray(X509Certificate[]::new);
 
-        X509Certificate[] certChain =  new X509Certificate[certChainList.size()];
-        certChainList.toArray(certChain);
-
-        jks.setKeyEntry(BROKER_KEY_ALIAS, certificateUpdate.getKeyPair().getPrivate(), jksPassword.toCharArray(),
-            certChain);
+        jks.setKeyEntry(BROKER_KEY_ALIAS, certificateUpdate.getKeyPair().getPrivate(),
+            jksPassword.toCharArray(), fullChain);
 
         try {
             commit();

--- a/integration/src/main/java/com/aws/greengrass/mqtt/moquette/BrokerKeyStore.java
+++ b/integration/src/main/java/com/aws/greengrass/mqtt/moquette/BrokerKeyStore.java
@@ -20,8 +20,11 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class BrokerKeyStore {
     private static final Logger LOGGER = LogManager.getLogger(BrokerKeyStore.class);
@@ -75,8 +78,15 @@ public class BrokerKeyStore {
      * @throws KeyStoreException If unable to set key entry.
      */
     public void updateServerCertificate(CertificateUpdateEvent certificateUpdate) throws KeyStoreException {
-        // TODO: Support certificate chains
-        Certificate[] certChain = {certificateUpdate.getCertificate()};
+        List<X509Certificate> certChainList = new ArrayList<>();
+        // Add server cert as first entry to the certificate chain
+        certChainList.add(certificateUpdate.getCertificate());
+        // Add rest of the CA certificate chain
+        certChainList.addAll(Arrays.asList(certificateUpdate.getCaCertificates()));
+
+        X509Certificate[] certChain =  new X509Certificate[certChainList.size()];
+        certChainList.toArray(certChain);
+
         jks.setKeyEntry(BROKER_KEY_ALIAS, certificateUpdate.getKeyPair().getPrivate(), jksPassword.toCharArray(),
             certChain);
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**=
This change adds the support for full certificate chains that includes server certificate and any intermediate CAs that signed the server certificate in order. 

**Why is this change necessary:**
This is needed for mutual trust establishment in local discovery scenarios where the client devices cannot obtain the CA through cloud but rely on this cert chain during TLS handshake. 

**How was this change tested:**
Tested end-to-end manually + all existing tests pass

Note: requires https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/125/

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
