### PR TITLE
chore: exclude H2 admin console from shaded jar

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -383,6 +383,7 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>org/h2/server/web/*</exclude>
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Excludes `org/h2/server/web/*` classes from our shaded jar

**Why is this change necessary:**

**How was this change tested:**
* manually verified that the shaded jar does not contain `org/h2/server/web/*` classes
* manually deployed moquette and verified it starts up and client devices can publish/subscribe messages

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
