### PR TITLE
fix: invalid session ID bug

### DIFF
--- a/integration/src/main/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizer.java
+++ b/integration/src/main/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizer.java
@@ -67,7 +67,7 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
         try {
             canConnect = canDevicePerform(sessionId, "mqtt:connect", "mqtt:clientId:" + clientId);
         } catch (InvalidSessionException e) {
-            LOG.error("{}: {}", e.getClass().getSimpleName(), e.getMessage());
+            LOG.debug("{}: {}", e.getClass().getSimpleName(), e.getMessage());
             try {
                 sessionPair = getOrCreateSessionForClient(clientId, username);
                 sessionId = sessionPair.getSession();
@@ -145,7 +145,7 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
         try {
             canPerform = canDevicePerform(sessionPair.getSession(), operation, resource);
         } catch (InvalidSessionException e) {
-            LOG.error("{}: {}", e.getClass().getSimpleName(), e.getMessage());
+            LOG.atError().kv(SESSION_ID, sessionPair.getSession()).cause(e).log("Session ID is invalid");
         } catch (AuthorizationException e) {
             LOG.atError().kv(SESSION_ID, sessionPair.getSession()).cause(e).log("Authorization Exception");
         }

--- a/integration/src/main/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizer.java
+++ b/integration/src/main/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizer.java
@@ -54,7 +54,6 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
         // Retrieve session ID and construct authorization request for MQTT CONNECT
         UserSessionPair sessionPair;
         String sessionId;
-        boolean canConnect = false;
         try {
             sessionPair = getOrCreateSessionForClient(clientId, username);
             sessionId = sessionPair.getSession();
@@ -64,6 +63,7 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
                     + "client ID and has a valid AWS IoT client certificate.");
             return false;
         }
+        boolean canConnect = false;
         try {
             canConnect = canDevicePerform(sessionId, "mqtt:connect", "mqtt:clientId:" + clientId);
         } catch (InvalidSessionException e) {

--- a/integration/src/test/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizerTest.java
+++ b/integration/src/test/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizerTest.java
@@ -47,7 +47,7 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
         when(mockClientDevicesAuthService.authorizeClientDeviceAction(authorizationRequest)).thenReturn(doAllow);
     }
 
-    void configureAuthResponseCDA(String session, String operation, String resource, boolean doAllow)
+    void configureAuthResponseException(String session, String operation, String resource, boolean doAllow)
         throws AuthorizationException {
         AuthorizationRequest authorizationRequest =
             AuthorizationRequest.builder().sessionId(session).operation(operation).resource(resource).build();
@@ -64,12 +64,12 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
         configureConnectResponse(DEFAULT_SESSION, DEFAULT_CLIENT, doAllow);
     }
 
-    void configureConnectResponseCDA(String session, String clientId, boolean doAllow) throws AuthorizationException {
-        configureAuthResponseCDA(session, "mqtt:connect", "mqtt:clientId:" + clientId, doAllow);
+    void configureConnectResponseException(String session, String clientId, boolean doAllow) throws AuthorizationException {
+        configureAuthResponseException(session, "mqtt:connect", "mqtt:clientId:" + clientId, doAllow);
     }
 
-    void configureConnectResponseCDA(boolean doAllow) throws AuthorizationException {
-        configureConnectResponseCDA(DEFAULT_SESSION, DEFAULT_CLIENT, doAllow);
+    void configureConnectResponseException(boolean doAllow) throws AuthorizationException {
+        configureConnectResponseException(DEFAULT_SESSION, DEFAULT_CLIENT, doAllow);
     }
 
     void configurePublishResponse(String session, String topic, boolean doAllow) throws AuthorizationException {
@@ -258,7 +258,7 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
         ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockClientDevicesAuthService);
 
         when(mockClientDevicesAuthService.getClientDeviceAuthToken(anyString(), anyMap())).thenReturn(DEFAULT_SESSION);
-        configureConnectResponseCDA(true);
+        configureConnectResponseException(true);
 
         assertThat(authorizer.checkValid(DEFAULT_CLIENT, DEFAULT_PEER_CERT, DEFAULT_PASSWORD), is(true));
     }
@@ -270,7 +270,7 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
         ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockClientDevicesAuthService);
 
         when(mockClientDevicesAuthService.getClientDeviceAuthToken(anyString(), anyMap())).thenReturn(DEFAULT_SESSION);
-        configureConnectResponseCDA(true);
+        configureConnectResponseException(true);
         configureSubscribeResponse(true);
         configurePublishResponse(true);
 

--- a/integration/src/test/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizerTest.java
+++ b/integration/src/test/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizerTest.java
@@ -252,18 +252,6 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_authorizedClientAndInvalidSession_WHEN_checkValid_THEN_returnsTrue(ExtensionContext context) throws
-        AuthenticationException, AuthorizationException {
-        ignoreExceptionOfType(context, InvalidSessionException.class);
-        ClientDeviceAuthorizer authorizer = new ClientDeviceAuthorizer(mockClientDevicesAuthService);
-
-        when(mockClientDevicesAuthService.getClientDeviceAuthToken(anyString(), anyMap())).thenReturn(DEFAULT_SESSION);
-        configureConnectResponseException(true);
-
-        assertThat(authorizer.checkValid(DEFAULT_CLIENT, DEFAULT_PEER_CERT, DEFAULT_PASSWORD), is(true));
-    }
-
-    @Test
     void GIVEN_authorizedClientAndInvalidSession_WHEN_canReadCanWrite_THEN_returnsTrue(ExtensionContext context) throws
         AuthenticationException, AuthorizationException {
         ignoreExceptionOfType(context, InvalidSessionException.class);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Refactored the code to throw the CDA InvalidSessionException in checkValid() instead of canDevicePerform(). This allows us to retry once to reconnect if an asynchronous disconnect event happens.

**Why is this change necessary:**
A race condition occurs when a user tries to connect -> disconnect -> reconnect. Instead, what can happen is connect -> connect -> disconnect since the disconnect is asynchronous and the user will no longer have a valid session. This change makes the code more robust by retrying once if a disconnect event happens in between the getOrCreateSessionForClient() and canDevicePerform() function calls in checkValid().

**How was this change tested:**
Added some more test cases and ran all of the existing test cases against the code changes.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
