### PR TITLE
fix: ensure the session we are closing is not the current session

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>client-devices-auth</artifactId>
-            <version>2.2.0-SNAPSHOT</version>
+            <version>2.4.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -387,6 +387,39 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>add-integration-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/integrationtests/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-integration-test-resource</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>src/integrationtests/resources</directory>
+                                </resource>
+                            </resources>
                         </configuration>
                     </execution>
                 </executions>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>client-devices-auth</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/integration/src/integrationtests/java/com/aws/greengrass/integrationtests/ClientDeviceAuthorizerIntegrationTest.java
+++ b/integration/src/integrationtests/java/com/aws/greengrass/integrationtests/ClientDeviceAuthorizerIntegrationTest.java
@@ -34,6 +34,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.KeyStoreException;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Optional;
@@ -64,6 +65,7 @@ public class ClientDeviceAuthorizerIntegrationTest {
         ignoreExceptionOfType(context, NoSuchFileException.class); // Loading CA keystore
         ignoreExceptionOfType(context, NullPointerException.class); // Uploading Core Device CA
         ignoreExceptionOfType(context, KeyStoreException.class);
+        ignoreExceptionOfType(context, UnrecoverableKeyException.class);
 
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");

--- a/integration/src/integrationtests/java/com/aws/greengrass/integrationtests/ClientDeviceAuthorizerIntegrationTest.java
+++ b/integration/src/integrationtests/java/com/aws/greengrass/integrationtests/ClientDeviceAuthorizerIntegrationTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests;
+
+import com.aws.greengrass.clientdevices.auth.api.ClientDevicesAuthServiceApi;
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
+import com.aws.greengrass.clientdevices.auth.iot.Certificate;
+import com.aws.greengrass.clientdevices.auth.iot.CertificateRegistry;
+import com.aws.greengrass.clientdevices.auth.iot.Thing;
+import com.aws.greengrass.clientdevices.auth.iot.infra.ThingRegistry;
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.integrationtests.helpers.CertificateTestHelpersMoquette;
+import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqtt.moquette.ClientDeviceAuthorizer;
+import com.aws.greengrass.mqtt.moquette.MQTTService;
+import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import io.moquette.broker.subscriptions.Topic;
+import io.moquette.interception.messages.InterceptDisconnectMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.NoSuchFileException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith({GGExtension.class, MockitoExtension.class})
+public class ClientDeviceAuthorizerIntegrationTest {
+    private Kernel kernel;
+    private static final String DEFAULT_CLIENT = "myThing";
+    private static final String DEFAULT_TOPIC = "topic";
+    private static final byte[] DEFAULT_PASSWORD = "".getBytes(StandardCharsets.UTF_8);
+    private static final long TEST_TIME_OUT_SEC = 30L;
+    @TempDir
+    Path rootDir;
+    private Certificate certificate;
+    private String clientPem;
+
+    @BeforeEach
+    void setup(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, SpoolerStoreException.class);
+        ignoreExceptionOfType(context, NoSuchFileException.class); // Loading CA keystore
+        // Set this property for kernel to scan its own classpath to find plugins
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
+        startNucleusWithConfig();
+
+        List<X509Certificate> clientCertificates = CertificateTestHelpersMoquette.createClientCertificates(1);
+        String clientPem = CertificateHelper.toPem(clientCertificates.get(0));
+        CertificateRegistry certificateRegistry = kernel.getContext().get(CertificateRegistry.class);
+        Certificate cert = certificateRegistry.getOrCreateCertificate(clientPem);
+        cert.setStatus(Certificate.Status.ACTIVE);
+
+        // activate certificate
+        certificateRegistry.updateCertificate(cert);
+        this.certificate = cert;
+        this.clientPem = clientPem;
+
+        registerThing();
+    }
+
+    @AfterEach
+    void cleanup() {
+        kernel.shutdown();
+    }
+
+    void startNucleusWithConfig() throws InterruptedException {
+        kernel = new Kernel();
+
+        CountDownLatch serviceRunning = new CountDownLatch(1);
+        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
+            getClass().getResource("config.yaml").toString());
+        GlobalStateChangeListener listener = (GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(MQTTService.SERVICE_NAME) && service.getState().equals(State.RUNNING)) {
+                serviceRunning.countDown();
+            }
+        };
+        kernel.getContext().addGlobalStateChangeListener(listener);
+        kernel.launch();
+        assertTrue(serviceRunning.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
+        kernel.getContext().removeGlobalStateChangeListener(listener);
+    }
+
+    void registerThing() {
+        ThingRegistry thingRegistry = kernel.getContext().get(ThingRegistry.class);
+        Thing myThing = thingRegistry.createThing(DEFAULT_CLIENT);
+        myThing.attachCertificate(certificate.getCertificateId());
+        thingRegistry.updateThing(myThing);
+    }
+
+    @Test
+    void GIVEN_duplicate_client_ids_WHEN_check_valid_THEN_can_read_returns_true() {
+        ClientDevicesAuthServiceApi clientDevicesAuthServiceApi = kernel.getContext().get(ClientDevicesAuthServiceApi.class);
+
+        ClientDeviceAuthorizer clientDeviceAuthorizer = new ClientDeviceAuthorizer(clientDevicesAuthServiceApi);
+
+        Topic topic = new Topic(DEFAULT_TOPIC);
+
+        assert(clientDeviceAuthorizer.checkValid(DEFAULT_CLIENT, this.clientPem, DEFAULT_PASSWORD));
+        assert(clientDeviceAuthorizer.checkValid(DEFAULT_CLIENT, this.clientPem, DEFAULT_PASSWORD));
+        assert(clientDeviceAuthorizer.canRead(topic, this.clientPem, DEFAULT_CLIENT));
+    }
+
+    @Test
+    void GIVEN_authorized_client_WHEN_session_closes_THEN_can_read_returns_true() {
+        ClientDevicesAuthServiceApi clientDevicesAuthServiceApi = kernel.getContext().get(ClientDevicesAuthServiceApi.class);
+
+        ClientDeviceAuthorizer clientDeviceAuthorizer = new ClientDeviceAuthorizer(clientDevicesAuthServiceApi);
+
+        ClientDeviceAuthorizer.ConnectionTerminationListener connectionTerminationListener =
+            clientDeviceAuthorizer.new ConnectionTerminationListener();
+
+        Topic topic = new Topic(DEFAULT_TOPIC);
+
+        assert(clientDeviceAuthorizer.checkValid(DEFAULT_CLIENT, this.clientPem, DEFAULT_PASSWORD));
+
+        InterceptDisconnectMessage msg = new InterceptDisconnectMessage(DEFAULT_CLIENT, this.clientPem);
+        connectionTerminationListener.onDisconnect(msg);
+
+        assert(clientDeviceAuthorizer.canRead(topic, this.clientPem, DEFAULT_CLIENT));
+    }
+}
+

--- a/integration/src/integrationtests/java/com/aws/greengrass/integrationtests/ClientDeviceAuthorizerIntegrationTest.java
+++ b/integration/src/integrationtests/java/com/aws/greengrass/integrationtests/ClientDeviceAuthorizerIntegrationTest.java
@@ -54,7 +54,7 @@ public class ClientDeviceAuthorizerIntegrationTest {
     private static final long TEST_TIME_OUT_SEC = 30L;
     @TempDir
     Path rootDir;
-    private Optional<String> certId = Optional.of("certId");
+    private final Optional<String> certId = Optional.of("certId");
     private String clientPem;
     @Mock
     IotAuthClient iotAuthClient;
@@ -80,7 +80,7 @@ public class ClientDeviceAuthorizerIntegrationTest {
         kernel.shutdown();
     }
 
-    void startNucleusWithConfig() throws InterruptedException {
+    private void startNucleusWithConfig() throws InterruptedException {
         kernel = new Kernel();
         kernel.getContext().put(IotAuthClient.class, iotAuthClient);
 

--- a/integration/src/integrationtests/java/com/aws/greengrass/integrationtests/helpers/CertificateTestHelpersMoquette.java
+++ b/integration/src/integrationtests/java/com/aws/greengrass/integrationtests/helpers/CertificateTestHelpersMoquette.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.helpers;
+
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
+import com.aws.greengrass.util.EncryptionUtils;
+import com.aws.greengrass.util.Pair;
+import com.aws.greengrass.util.Utils;
+import org.apache.commons.io.IOUtils;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.cert.CertIOException;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.X509KeyUsage;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.CertPath;
+import java.security.cert.CertPathValidator;
+import java.security.cert.CertPathValidatorException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.PKIXParameters;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+
+
+public final class CertificateTestHelpersMoquette {
+    private static final int DEFAULT_TEST_CA_DURATION_SECONDS = 3600;
+    public static final String KEY_TYPE_RSA = "RSA";
+    public static final String RSA_SIGNING_ALGORITHM = "SHA256withRSA";
+    public static final String KEY_TYPE_EC = "EC";
+    public static final String ECDSA_SIGNING_ALGORITHM = "SHA256withECDSA";
+    public static final ImmutableMap<String, String> CERTIFICATE_SIGNING_ALGORITHM =
+            ImmutableMap.of(KEY_TYPE_RSA, RSA_SIGNING_ALGORITHM, KEY_TYPE_EC, ECDSA_SIGNING_ALGORITHM);
+
+    private CertificateTestHelpersMoquette() {
+    }
+
+    static {
+        // If not added "BC" is not recognized as the security provider
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    private enum CertificateTypes {
+        ROOT_CA, INTERMEDIATE_CA, SERVER_CERTIFICATE, CLIENT_CERTIFICATE
+    }
+
+    public static X509Certificate createRootCertificateAuthority(String commonName, KeyPair kp)
+            throws CertificateException, OperatorCreationException, CertIOException, NoSuchAlgorithmException {
+        return createCertificate(null, commonName, kp.getPublic(), kp.getPrivate(), CertificateTypes.ROOT_CA);
+    }
+
+    public static X509Certificate createIntermediateCertificateAuthority(X509Certificate caCert, String commonName,
+                                                                         PublicKey publicKey, PrivateKey caPrivateKey)
+            throws NoSuchAlgorithmException, CertificateException, CertIOException, OperatorCreationException {
+        return createCertificate(caCert, commonName, publicKey, caPrivateKey, CertificateTypes.INTERMEDIATE_CA);
+    }
+
+    public static X509Certificate createServerCertificate(X509Certificate caCert, String commonName,
+                                                          PublicKey publicKey, PrivateKey caPrivateKey)
+            throws NoSuchAlgorithmException, CertificateException, IOException, OperatorCreationException {
+        return createCertificate(caCert, commonName, publicKey, caPrivateKey, CertificateTypes.SERVER_CERTIFICATE);
+    }
+
+    public static X509Certificate createClientCertificate(X509Certificate caCert, String commonName,
+                                                          PublicKey publicKey, PrivateKey caPrivateKey)
+            throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, CertIOException {
+        return createCertificate(caCert, commonName, publicKey, caPrivateKey, CertificateTypes.CLIENT_CERTIFICATE);
+    }
+
+    private static X509Certificate createCertificate(X509Certificate caCert, String commonName, PublicKey publicKey,
+                                                     PrivateKey caPrivateKey, CertificateTypes type)
+            throws NoSuchAlgorithmException, CertIOException, CertificateException, OperatorCreationException {
+        Pair<Date, Date> dateRange = getValidityDateRange();
+        X500Name subject = getX500Name(commonName);
+
+        X509v3CertificateBuilder builder;
+        if (type == CertificateTypes.ROOT_CA) {
+            builder = new JcaX509v3CertificateBuilder(subject, getSerialNumber(), dateRange.getLeft(),
+                    dateRange.getRight(), subject, publicKey);
+        } else {
+            builder = new JcaX509v3CertificateBuilder(caCert, getSerialNumber(), dateRange.getLeft(),
+                    dateRange.getRight(), subject, publicKey);
+        }
+
+        buildCertificateExtensions(builder, caCert, publicKey, type);
+        X509CertificateHolder certHolder = signCertificate(builder, caPrivateKey);
+        return new JcaX509CertificateConverter().setProvider("BC").getCertificate(certHolder);
+    }
+
+    private static X509CertificateHolder signCertificate(X509v3CertificateBuilder certBuilder, PrivateKey privateKey)
+            throws OperatorCreationException {
+        String signingAlgorithm = CERTIFICATE_SIGNING_ALGORITHM.get(privateKey.getAlgorithm());
+        final ContentSigner contentSigner =
+                new JcaContentSignerBuilder(signingAlgorithm).setProvider("BC").build(privateKey);
+
+        return certBuilder.build(contentSigner);
+    }
+
+    private static void buildCertificateExtensions(X509v3CertificateBuilder builder, X509Certificate caCert,
+                                                   PublicKey publicKey, CertificateTypes type)
+            throws NoSuchAlgorithmException, CertificateEncodingException, CertIOException {
+        JcaX509ExtensionUtils extUtils = new JcaX509ExtensionUtils();
+        builder.addExtension(Extension.subjectKeyIdentifier, false, extUtils.createSubjectKeyIdentifier(publicKey));
+
+        if (type == CertificateTypes.ROOT_CA) {
+            builder.addExtension(Extension.authorityKeyIdentifier, false,
+                            extUtils.createAuthorityKeyIdentifier(publicKey))
+                    .addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+        }
+
+        if (type == CertificateTypes.INTERMEDIATE_CA) {
+            builder.addExtension(Extension.authorityKeyIdentifier, false, extUtils.createAuthorityKeyIdentifier(caCert))
+                    .addExtension(Extension.basicConstraints, true, new BasicConstraints(true))
+                    .addExtension(Extension.keyUsage, true, new X509KeyUsage(
+                            X509KeyUsage.digitalSignature | X509KeyUsage.keyCertSign | X509KeyUsage.cRLSign));
+        }
+
+        if (type == CertificateTypes.SERVER_CERTIFICATE) {
+            builder.addExtension(Extension.authorityKeyIdentifier, false, extUtils.createAuthorityKeyIdentifier(caCert))
+                    .addExtension(Extension.basicConstraints, true, new BasicConstraints(false))
+                    .addExtension(Extension.extendedKeyUsage, true,
+                            new ExtendedKeyUsage(KeyPurposeId.id_kp_serverAuth));
+        }
+
+        if (type == CertificateTypes.CLIENT_CERTIFICATE) {
+            builder.addExtension(Extension.authorityKeyIdentifier, false, extUtils.createAuthorityKeyIdentifier(caCert))
+                    .addExtension(Extension.basicConstraints, true, new BasicConstraints(false))
+                    .addExtension(Extension.extendedKeyUsage, true,
+                            new ExtendedKeyUsage(KeyPurposeId.id_kp_clientAuth));
+        }
+    }
+
+    private static BigInteger getSerialNumber() {
+        return new BigInteger(160, new SecureRandom());
+    }
+
+    private static Pair<Date, Date> getValidityDateRange() {
+        Instant now = Instant.now();
+        // TODO: caller should pass a clock or date range in instead
+        Date notBefore = Date.from(now.minusSeconds(1));
+        Date notAfter = Date.from(now.plusSeconds(DEFAULT_TEST_CA_DURATION_SECONDS));
+        return new Pair(notBefore, notAfter);
+    }
+
+    private static X500Name getX500Name(String commonName) {
+        X500NameBuilder nameBuilder = new X500NameBuilder(X500Name.getDefaultStyle());
+        nameBuilder.addRDN(BCStyle.C, "US");
+        nameBuilder.addRDN(BCStyle.O, "Internet Widgits Pty Ltd");
+        nameBuilder.addRDN(BCStyle.OU, "Amazon Web Services");
+        nameBuilder.addRDN(BCStyle.ST, "Washington");
+        nameBuilder.addRDN(BCStyle.L, "Seattle");
+        nameBuilder.addRDN(BCStyle.CN, commonName);
+
+        return nameBuilder.build();
+    }
+
+
+    /**
+     * Verifies if one certificate was signed by another.
+     *
+     * @param issuerCA    X509Certificate issuer cert
+     * @param certificate X509Certificate signed cert
+     */
+    public static boolean wasCertificateIssuedBy(X509Certificate issuerCA, X509Certificate certificate)
+            throws CertificateException {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        List<X509Certificate> leafCertificate = Arrays.asList(certificate);
+        CertPath leafCertPath = cf.generateCertPath(leafCertificate);
+
+        try {
+            CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
+            TrustAnchor trustAnchor = new TrustAnchor(issuerCA, null);
+            PKIXParameters validationParams = new PKIXParameters(new HashSet<>(Collections.singletonList(trustAnchor)));
+            validationParams.setRevocationEnabled(false);
+            cpv.validate(leafCertPath, validationParams);
+            return true;
+        } catch (CertPathValidatorException | InvalidAlgorithmParameterException | NoSuchAlgorithmException e) {
+            return false;
+        }
+    }
+
+    public static List<X509Certificate> createClientCertificates(int amount) throws Exception {
+        KeyPair rootKeyPair = CertificateStore.newRSAKeyPair(2048);
+        X509Certificate rootCA = CertificateTestHelpersMoquette.createRootCertificateAuthority("root", rootKeyPair);
+
+        List<X509Certificate> clientCertificates = new ArrayList<>();
+
+        for (int i = 0; i < amount; i++) {
+            KeyPair clientKeyPair = CertificateStore.newRSAKeyPair(2048);
+
+            clientCertificates.add(createClientCertificate(rootCA, "AWS IoT Certificate", clientKeyPair.getPublic(),
+                    rootKeyPair.getPrivate()));
+        }
+
+        return clientCertificates;
+    }
+
+    public static List<X509Certificate> loadX509Certificate(String pem) throws IOException, CertificateException {
+
+        try (InputStream targetStream = IOUtils.toInputStream(pem)) {
+            CertificateFactory factory = CertificateFactory.getInstance("X.509");
+
+            return new ArrayList<>((Collection<? extends X509Certificate>) factory.generateCertificates(targetStream));
+        }
+    }
+
+    @SuppressWarnings("PMD.AvoidFileStream")
+    public static void writeToPath(Path filePath, String boundary, List<byte[]> encodings) throws IOException {
+        File file = filePath.toFile();
+
+        if (!Files.exists(filePath)) {
+            Utils.createPaths(filePath.getParent());
+        }
+
+        try (FileWriter fw = new FileWriter(file, true)) {
+            for (byte[] encoding : encodings) {
+                fw.write(EncryptionUtils.encodeToPem(boundary, encoding));
+            }
+        }
+    }
+}

--- a/integration/src/integrationtests/resources/com/aws/greengrass/integrationtests/config.yaml
+++ b/integration/src/integrationtests/resources/com/aws/greengrass/integrationtests/config.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+services:
+    aws.greengrass.Nucleus: {}
+    aws.greengrass.clientdevices.Auth:
+        configuration:
+            deviceGroups:
+                formatVersion: "2021-03-05"
+                definitions:
+                    myThing:
+                        selectionRule: "thingName:myThing"
+                        policyName: "thingAccessPolicy"
+                policies:
+                    thingAccessPolicy:
+                        policyStatement1:
+                            statementDescription: "Allow client devices to perform all actions"
+                            operations:
+                                - "*"
+                            resources:
+                                - "*"
+    aws.greengrass.clientdevices.mqtt.Moquette: {}
+    main:
+        lifecycle:
+            install:
+                all: echo All installed
+        dependencies:
+            - aws.greengrass.Nucleus
+            - aws.greengrass.clientdevices.Auth
+            - aws.greengrass.clientdevices.mqtt.Moquette
+

--- a/integration/src/integrationtests/resources/com/aws/greengrass/integrationtests/config.yaml
+++ b/integration/src/integrationtests/resources/com/aws/greengrass/integrationtests/config.yaml
@@ -2,8 +2,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
+
+---
 services:
-    aws.greengrass.Nucleus: {}
     aws.greengrass.clientdevices.Auth:
         configuration:
             deviceGroups:
@@ -20,10 +21,7 @@ services:
                                 - "*"
                             resources:
                                 - "*"
-    aws.greengrass.clientdevices.mqtt.Moquette: {}
     main:
         dependencies:
-            - aws.greengrass.Nucleus
             - aws.greengrass.clientdevices.Auth
-            - aws.greengrass.clientdevices.mqtt.Moquette
 

--- a/integration/src/integrationtests/resources/com/aws/greengrass/integrationtests/config.yaml
+++ b/integration/src/integrationtests/resources/com/aws/greengrass/integrationtests/config.yaml
@@ -22,9 +22,6 @@ services:
                                 - "*"
     aws.greengrass.clientdevices.mqtt.Moquette: {}
     main:
-        lifecycle:
-            install:
-                all: echo All installed
         dependencies:
             - aws.greengrass.Nucleus
             - aws.greengrass.clientdevices.Auth

--- a/integration/src/main/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizer.java
+++ b/integration/src/main/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizer.java
@@ -135,13 +135,10 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
         boolean canPerform = false;
         try {
             UserSessionPair sessionPair = getOrCreateSessionForClient(client, user);
-            if (sessionPair == null) {
-                return false;
-            }
             try {
                 canPerform = canDevicePerform(sessionPair.getSession(), operation, resource);
             } catch (InvalidSessionException e) {
-                LOG.atError().kv(SESSION_ID, sessionPair.getSession()).cause(e).log("Session ID is invalid");
+                LOG.atError().kv(SESSION_ID, sessionPair.getSession()).log("Session ID is invalid");
                 // Remove session in Moquette since it's not in CDA
                 clientToSessionMap.remove(client, sessionPair);
             } catch (AuthorizationException e) {

--- a/integration/src/main/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizer.java
+++ b/integration/src/main/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizer.java
@@ -68,6 +68,7 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
             canConnect = canDevicePerform(sessionId, "mqtt:connect", "mqtt:clientId:" + clientId);
         } catch (InvalidSessionException e) {
             LOG.debug("{}: {}", e.getClass().getSimpleName(), e.getMessage());
+            // Remove session in Moquette since it's not in CDA
             clientToSessionMap.remove(clientId, sessionPair);
             try {
                 sessionPair = getOrCreateSessionForClient(clientId, username);
@@ -82,6 +83,8 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
                 canConnect = canDevicePerform(sessionId, "mqtt:connect", "mqtt:clientId:" + clientId);
             } catch (InvalidSessionException err) {
                 LOG.error("{}: {}", err.getClass().getSimpleName(), err.getMessage());
+                // Remove session in Moquette since it's not in CDA
+                clientToSessionMap.remove(clientId, sessionPair);
             } catch (AuthorizationException err) {
                 LOG.atWarn().kv(SESSION_ID, sessionId).cause(err).log("Authorization Exception");
             }
@@ -113,12 +116,7 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
     @Override
     public boolean canWrite(Topic topic, String user, String client) {
         String resource = "mqtt:topic:" + topic;
-        boolean canPerform = false;
-        try {
-            canPerform = canDevicePerform(getOrCreateSessionForClient(client, user), "mqtt:publish", resource);
-        } catch (AuthenticationException e) {
-            LOG.atWarn().cause(e).kv(CLIENT_ID, client).log("Unable to re-authenticate client.");
-        }
+        boolean canPerform = canDevicePerform(client, user, "mqtt:publish", resource);
         LOG.atDebug().kv("topic", topic).kv("isAllowed", canPerform).kv(CLIENT_ID, client)
             .log("MQTT publish request");
         return canPerform;
@@ -127,31 +125,30 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
     @Override
     public boolean canRead(Topic topic, String user, String client) {
         String resource = "mqtt:topicfilter:" + topic;
-        boolean canPerform = false;
-        try {
-            canPerform = canDevicePerform(getOrCreateSessionForClient(client, user), "mqtt:subscribe", resource);
-        } catch (AuthenticationException e) {
-            LOG.atWarn().cause(e).kv(CLIENT_ID, client).log("Unable to re-authenticate client.");
-        }
+        boolean canPerform = canDevicePerform(client, user, "mqtt:subscribe", resource);
         LOG.atDebug().kv("topic", topic).kv("isAllowed", canPerform).kv(CLIENT_ID, client)
             .log("MQTT subscribe request");
         return canPerform;
     }
 
-    private boolean canDevicePerform(UserSessionPair sessionPair, String operation, String resource) {
-        if (sessionPair == null) {
-            return false;
-        }
+    private boolean canDevicePerform(String client, String user, String operation, String resource) {
         boolean canPerform = false;
         try {
-            canPerform = canDevicePerform(sessionPair.getSession(), operation, resource);
-        } catch (InvalidSessionException e) {
-            LOG.atError().kv(SESSION_ID, sessionPair.getSession()).cause(e).log("Session ID is invalid");
-            //TODO: We have a session in moquette but not in cda. Maybe here we remove the session from moquette
-            // since its invalid, and then we retry with a new session
-            // we don't have the clientId here
-        } catch (AuthorizationException e) {
-            LOG.atError().kv(SESSION_ID, sessionPair.getSession()).cause(e).log("Authorization Exception");
+            UserSessionPair sessionPair = getOrCreateSessionForClient(client, user);
+            if (sessionPair == null) {
+                return false;
+            }
+            try {
+                canPerform = canDevicePerform(sessionPair.getSession(), operation, resource);
+            } catch (InvalidSessionException e) {
+                LOG.atError().kv(SESSION_ID, sessionPair.getSession()).cause(e).log("Session ID is invalid");
+                // Remove session in Moquette since it's not in CDA
+                clientToSessionMap.remove(client, sessionPair);
+            } catch (AuthorizationException e) {
+                LOG.atError().kv(SESSION_ID, sessionPair.getSession()).cause(e).log("Authorization Exception");
+            }
+        } catch (AuthenticationException e) {
+            LOG.atWarn().cause(e).kv(CLIENT_ID, client).log("Unable to re-authenticate client.");
         }
         return canPerform;
     }
@@ -185,7 +182,9 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
         mqttCredentials.put(CLIENT_ID, clientId);
 
         String sessionId = clientDevicesAuthService.getClientDeviceAuthToken(MQTT_CREDENTIAL, mqttCredentials);
-        return new UserSessionPair(username, sessionId);
+        UserSessionPair sessionPair = new UserSessionPair(username, sessionId);
+        clientToSessionMap.put(clientId, sessionPair);
+        return sessionPair;
     }
 
     class UserSessionPair {

--- a/integration/src/main/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizer.java
+++ b/integration/src/main/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizer.java
@@ -68,6 +68,7 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
             canConnect = canDevicePerform(sessionId, "mqtt:connect", "mqtt:clientId:" + clientId);
         } catch (InvalidSessionException e) {
             LOG.debug("{}: {}", e.getClass().getSimpleName(), e.getMessage());
+            clientToSessionMap.remove(clientId, sessionPair);
             try {
                 sessionPair = getOrCreateSessionForClient(clientId, username);
                 sessionId = sessionPair.getSession();
@@ -146,6 +147,9 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
             canPerform = canDevicePerform(sessionPair.getSession(), operation, resource);
         } catch (InvalidSessionException e) {
             LOG.atError().kv(SESSION_ID, sessionPair.getSession()).cause(e).log("Session ID is invalid");
+            //TODO: We have a session in moquette but not in cda. Maybe here we remove the session from moquette
+            // since its invalid, and then we retry with a new session
+            // we don't have the clientId here
         } catch (AuthorizationException e) {
             LOG.atError().kv(SESSION_ID, sessionPair.getSession()).cause(e).log("Authorization Exception");
         }

--- a/integration/src/main/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizer.java
+++ b/integration/src/main/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizer.java
@@ -94,7 +94,7 @@ public class ClientDeviceAuthorizer implements IAuthenticator, IAuthorizatorPoli
                 .log("Successfully authenticated client device");
             String finalSessionId = sessionId;
             clientToSessionMap.compute(clientId, (k, v) -> {
-                if (v != null) {
+                if (v != null && !(finalSessionId.equals(v.getSession()))) {
                     LOG.atWarn().kv(CLIENT_ID, clientId).kv("Previous auth session", v.getSession())
                         .log("Duplicate client ID detected. Closing old auth session.");
                     clientDevicesAuthService.closeClientDeviceAuthSession(v.getSession());

--- a/integration/src/test/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizerTest.java
+++ b/integration/src/test/java/com/aws/greengrass/mqtt/moquette/ClientDeviceAuthorizerTest.java
@@ -125,7 +125,11 @@ public class ClientDeviceAuthorizerTest extends GGServiceTestUtil {
         ClientDeviceAuthorizer.UserSessionPair pair2 = authorizer.getSessionForClient(DEFAULT_CLIENT, USERNAME2);
         assertThat(pair2.getSession(), is("SESSION2"));
 
-        verify(mockClientDevicesAuthService).closeClientDeviceAuthSession("SESSION1");
+        mockClientDevicesAuthService.closeClientDeviceAuthSession("SESSION2");
+        assertThat(authorizer.getSessionForClient(DEFAULT_CLIENT, USERNAME2).getSession(), is("SESSION2"));
+        ClientDeviceAuthorizer.UserSessionPair pair3 = authorizer.getOrCreateSessionForClient(DEFAULT_CLIENT,
+            USERNAME2);
+        assertThat(pair3.getSession(), is("SESSION2"));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**
https://sim.amazon.com/issues/GG-43139

**Description of changes:**
Added a check to make sure that we don't close out an Auth session when we receive duplicate `mqtt:connect` authorization requests with identical client and session IDs. 

**Why is this change necessary:**
So we don't close out the auth session for a client id that should successfully be authorized.

**How was this change tested:**
Ran unit test suite and `GGAD-Can-moquette` canary. 
Added Integration testing.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
